### PR TITLE
fix(runtime): sweep DB retention on an interval, not once at boot

### DIFF
--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -131,7 +131,7 @@ import {
 } from "./main-session-event-worker.js";
 import { queuedMainSessionEventPromptEntry } from "./main-session-event-prompt.js";
 import {
-  runRuntimeDbMaintenance,
+  startRuntimeDbMaintenanceLoop,
   IDLE_DB_MAINTENANCE_PROGRESS,
   type DbMaintenanceProgress,
 } from "./db-maintenance.js";
@@ -4727,8 +4727,13 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     // data.db compaction for the next boot. Fire-and-forget with a built-in
     // start delay so it never competes with boot; fully self-guarded, so it
     // cannot crash the runtime. Skipped in test/embedded builds via option.
+    //
+    // Repeats on an interval rather than running once: a desktop that stays
+    // open for days would otherwise never prune again after boot, which is how
+    // data.db grew to multiple GB in the field. Stops on `onClose` via the
+    // shared abort controller.
     if (options.enableDbMaintenance !== false) {
-      void runRuntimeDbMaintenance({
+      void startRuntimeDbMaintenanceLoop({
         store,
         logger: {
           info: (message, meta) => app.log.info(meta ?? {}, message),

--- a/runtime/api-server/src/db-maintenance.test.ts
+++ b/runtime/api-server/src/db-maintenance.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   type DbMaintenanceStore,
   runRuntimeDbMaintenance,
+  startRuntimeDbMaintenanceLoop,
 } from "./db-maintenance.js";
 
 /** In-memory fake of the retention surface — no native DB needed. */
@@ -231,6 +232,102 @@ test("a small backlog is not heavy (stays a silent background sweep)", async () 
 
   assert.ok(progress.every((p) => p.heavy === false));
   assert.equal(progress.at(-1)?.done, true);
+});
+
+test("the loop sweeps repeatedly, not just once at boot", async () => {
+  const store = new FakeStore();
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+
+  // Every sweep emits exactly one "estimating" before it prunes, so counting
+  // them counts sweeps. A one-shot implementation never gets past 1 — which is
+  // precisely the bug that let data.db grow unbounded on long-lived installs.
+  let sweeps = 0;
+  const controller = new AbortController();
+  const loop = startRuntimeDbMaintenanceLoop({
+    store,
+    ...fastOpts,
+    intervalMs: 1,
+    requestCompaction: false,
+    signal: controller.signal,
+    onProgress: (p) => {
+      if (p.phase === "estimating") {
+        sweeps += 1;
+      }
+    },
+  });
+
+  const deadline = Date.now() + 2_000;
+  while (sweeps < 2 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  controller.abort();
+  await loop;
+
+  assert.ok(sweeps >= 2, `expected repeated sweeps, saw ${sweeps}`);
+});
+
+test("background sweeps can never raise the blocking boot screen", async () => {
+  const store = new FakeStore();
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.seed("s1", 200, "2026-01-01T00:00:00.000Z");
+
+  // BootGate blocks the UI on `heavy && !done`. The first sweep may legitimately
+  // be heavy; every later one must not be, or a mid-session background sweep
+  // could drop the user back onto the boot splash.
+  //
+  // Re-seed after each sweep so the backlog stays above the threshold — a
+  // workload that keeps producing prunable rows. Without that the estimate
+  // falls to zero after sweep 1 and `heavy` would read false whether or not the
+  // guard is doing anything.
+  const heavyBySweep: boolean[] = [];
+  const controller = new AbortController();
+  const loop = startRuntimeDbMaintenanceLoop({
+    store,
+    ...fastOpts,
+    intervalMs: 1,
+    heavyThreshold: 10, // trivially exceeded, so sweep 1 is heavy
+    requestCompaction: false,
+    signal: controller.signal,
+    onProgress: (p) => {
+      if (p.phase === "estimating") {
+        heavyBySweep.push(p.heavy);
+      }
+      if (p.phase === "done") {
+        store.seed("s1", 200, "2026-01-01T00:00:00.000Z");
+      }
+    },
+  });
+
+  const deadline = Date.now() + 2_000;
+  while (heavyBySweep.length < 2 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  controller.abort();
+  await loop;
+
+  assert.equal(heavyBySweep[0], true, "first sweep should be heavy here");
+  assert.ok(
+    heavyBySweep.slice(1).every((heavy) => heavy === false),
+    `later sweeps must never be heavy, saw ${JSON.stringify(heavyBySweep)}`,
+  );
+});
+
+test("the loop resolves on abort instead of running forever", async () => {
+  const store = new FakeStore();
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  const controller = new AbortController();
+
+  const loop = startRuntimeDbMaintenanceLoop({
+    store,
+    ...fastOpts,
+    // Would idle for an hour between sweeps if abort were ignored.
+    intervalMs: 3_600_000,
+    requestCompaction: false,
+    signal: controller.signal,
+  });
+
+  controller.abort();
+  await loop; // hangs the test run if the loop ignores the signal
 });
 
 test("aborting stops the sweep promptly", async () => {

--- a/runtime/api-server/src/db-maintenance.ts
+++ b/runtime/api-server/src/db-maintenance.ts
@@ -92,6 +92,12 @@ export interface DbMaintenanceOptions {
 }
 
 const DEFAULT_START_DELAY_MS = 30_000;
+/**
+ * Gap between background retention sweeps. Long enough to be invisible, short
+ * enough that a desktop left open for days can't accumulate an unbounded
+ * backlog between sweeps.
+ */
+const DEFAULT_REPEAT_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const DEFAULT_BATCH_SIZE = 5_000;
 const DEFAULT_PAUSE_MS = 250;
 const DEFAULT_COMPACT_AFTER_DELETES = 50_000;
@@ -335,4 +341,50 @@ export async function runRuntimeDbMaintenance(
   emitProgress("done", true);
 
   return result;
+}
+
+/**
+ * Run {@link runRuntimeDbMaintenance} on a repeating schedule until `signal`
+ * aborts. Resolves only on shutdown.
+ *
+ * One sweep enforces retention at the instant it runs, so a single boot-time
+ * call bounds nothing for an app that then stays open for days — which is how
+ * `data.db` reached multiple GB in the field *despite* the policy being
+ * enforced: the age cutoff only becomes eligible while the runtime is up, and
+ * nothing was re-checking it. Repeating the sweep is what actually bounds the
+ * table for a long-lived desktop.
+ *
+ * Sweeps after the first can never be flagged `heavy`. The blocking
+ * "Optimizing storage…" screen is a boot affordance keyed on
+ * `heavy && !done` (see BootGate), and a mid-session background sweep must not
+ * be able to raise it.
+ */
+export async function startRuntimeDbMaintenanceLoop(
+  options: DbMaintenanceOptions & {
+    /** Gap between sweeps. Defaults to 6h. */
+    intervalMs?: number;
+  },
+): Promise<void> {
+  const { intervalMs = DEFAULT_REPEAT_INTERVAL_MS, ...sweepOptions } = options;
+  const { signal } = sweepOptions;
+
+  // runRuntimeDbMaintenance never throws, so the loop needs no guard of its own.
+  await runRuntimeDbMaintenance(sweepOptions);
+
+  while (!signal?.aborted) {
+    try {
+      await sleep(intervalMs, undefined, { signal });
+    } catch {
+      return; // AbortError — shutdown requested.
+    }
+    if (signal?.aborted) {
+      return;
+    }
+    await runRuntimeDbMaintenance({
+      ...sweepOptions,
+      // The interval is already the boot-competition delay.
+      startDelayMs: 0,
+      heavyThreshold: Number.POSITIVE_INFINITY,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- The `session_output_events` retention sweep ran **exactly once**, fired from the `onReady` hook (`app.ts:4730`). A desktop left open for days never prunes again after boot — rows cross the age cutoff while the runtime is up, and nothing re-checks them.
- Adds `startRuntimeDbMaintenanceLoop`, which re-runs the existing sweep every 6h until the shutdown signal fires, and points `app.ts` at it.

This is a mechanism fix, not a policy change.

## Why it matters

Measured on my own install:

```
data.db                 1.9 GB
session_output_events   2.29M rows / 1.285 GB + 565 MB indexes
span                    2026-07-27 → 2026-08-17 (21 days)
```

That is 1.9 GB of the 2.0 GB `sandbox-host/state` directory. Because `maxAgeDays: 30` exceeds the 21 days of data present, **zero** rows were ever age-eligible — the policy was being enforced correctly, just never re-evaluated. Every session load, every SSE tail and every sidebar poll queries that table, which is exactly the "fine for ten minutes, sluggish after a day" profile.

## What this deliberately does *not* change

`DEFAULT_OUTPUT_EVENT_RETENTION` is untouched. Its comment records that 30d / 25k was *"Chosen with the product owner over the aggressive/conservative alternatives"* — so tightening it is a product call, not something to slip into a bug fix. Worth revisiting separately now that there is evidence about real-world growth.

## Risks

- **A background sweep must never re-block the UI.** `BootGate` blocks on `heavy && !done`, so sweeps after the first are pinned to `heavyThreshold: Infinity`. The first sweep keeps its existing heavy/progress behaviour, so the first-run "Optimizing storage…" screen is unchanged.
- The loop resolves on `dbMaintenanceAbort`, which `onClose` already fires — no new shutdown wiring.
- `runRuntimeDbMaintenance` is unchanged and still exported, so its 9 existing tests cover it as before.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `db-maintenance.test.ts` — 11/11 pass
- [x] Both new tests **mutation-verified**: making the loop non-repeating fails `the loop sweeps repeatedly…`; dropping the heavy guard fails `background sweeps can never raise the blocking boot screen`. (The second needed a rewrite — my first attempt passed under mutation because the backlog drained to zero and `heavy` read false either way.)
- [ ] `npm run runtime:test` — **fails on clean `main` too**, at `runtime/harnesses/src/pi.test.ts:77`, in a package this PR does not touch. That test asserts `browser_tools_enabled === false` for `workspace_session`, but `browserToolsEnabledForSessionKind` deliberately returns `true` for everything except `onboarding`. Stale test, pre-existing, filed separately.

## Note on CI coverage

The tests added here **do not currently run in CI**, for two independent reasons I found while validating this and am fixing in a follow-up:

1. `runtime-harnesses` and `runtime-channel-gateway` both have `test` scripts but appear in **no** CI filter, so they are never tested at all. (`runtime-api-server` *is* covered, by its own job — correcting an earlier version of this description that said otherwise.)
2. `api-server`'s `test` script uses an unquoted `src/**/*.test.ts`. It is the only runtime package with *nested* test files, so bun's shell expands the glob to just those 2 and passes them to node, shadowing node's own recursive expansion. Result: **13 of 1,106 tests run**. Quoting the glob runs all 1,106 — 1,079 pass, 24 fail.

## Docs

- [ ] n/a — no setup, packaging, or public behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
