### PR TITLE
fix(runtime): repair three bugs the unrun api-server suite was hiding

### DIFF
--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -12050,7 +12050,10 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       if (!capability) {
         return reply.code(404).send({ error: "capability not found" });
       }
-      const result = installCapability({
+      // installCapability is async: without the await this replied with a
+      // pending promise, which serializes to `{}` — and responded before the
+      // install had actually finished.
+      const result = await installCapability({
         store,
         workspaceId,
         workspaceDir: store.workspaceDir(workspaceId),

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -7624,7 +7624,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     async (request, reply) => {
       const body = isRecord(request.body) ? request.body : {};
       try {
-        return runtimeAgentToolsService.listIntegrationCatalog({
+        // `await` — see the capability-install route: an un-awaited return of
+        // an async call rejects past its own try, leaving this catch dead.
+        return await runtimeAgentToolsService.listIntegrationCatalog({
           workspaceId: requiredCapabilityWorkspaceId({
             headers: request.headers as Record<string, unknown>,
             body,
@@ -8117,7 +8119,11 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       return sendError(reply, 400, "request body must be an object");
     }
     try {
-      return runtimeAgentToolsService.installCapability({
+      // `await`, not a bare return: installCapability is async, so without it
+      // its rejections escape this try and the catch below is dead code — the
+      // mapped {detail} error body silently became the generic error-handler
+      // shape for every failure this route can produce.
+      return await runtimeAgentToolsService.installCapability({
         workspaceId: requiredCapabilityWorkspaceId({
           headers: request.headers as Record<string, unknown>,
           body: request.body

--- a/runtime/api-server/src/awaited-service-routes.test.ts
+++ b/runtime/api-server/src/awaited-service-routes.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const appSource = fs.readFileSync(path.join(here, "app.ts"), "utf8");
+const serviceSource = fs.readFileSync(
+  path.join(here, "runtime-agent-tools.ts"),
+  "utf8",
+);
+
+/**
+ * `return somethingAsync()` inside a try/catch does NOT route rejections to
+ * that catch — the value is returned before it settles, and the enclosing
+ * async function adopts it outside the try. The catch becomes dead code, and
+ * these routes use it to map service errors onto their status and {detail}
+ * body; without it a failure falls through to the generic error handler, which
+ * has no statusCode to read for a plain Error and answers 500 where the route
+ * meant 400.
+ *
+ * This is easy to reintroduce whenever a service method is made async — which
+ * is how it arrived here — so guard the shape rather than the two known sites.
+ */
+function asyncServiceMethods(): Set<string> {
+  return new Set(
+    [...serviceSource.matchAll(/^\s{2}async\s+([a-zA-Z0-9_]+)\s*\(/gm)].map(
+      (match) => match[1]!,
+    ),
+  );
+}
+
+test("no route returns an async service call un-awaited inside a try/catch", () => {
+  const asyncMethods = asyncServiceMethods();
+  assert.ok(asyncMethods.size > 0, "found no async methods to check against");
+
+  const lines = appSource.split("\n");
+  const offenders: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i]!.match(
+      /^(\s*)return runtimeAgentToolsService\.([a-zA-Z0-9_]+)\(/,
+    );
+    if (!match) continue;
+    const [, indent, method] = match;
+    if (!asyncMethods.has(method!)) continue;
+
+    let inTry = false;
+    for (let j = i - 1; j >= 0 && j > i - 60; j -= 1) {
+      if (/^\s*app\.(post|get|put|delete|patch)/.test(lines[j]!)) break;
+      if (/^\s*try \{\s*$/.test(lines[j]!) && lines[j]!.search(/\S/) < indent!.length) {
+        inTry = true;
+        break;
+      }
+    }
+    if (!inTry) continue;
+
+    let hasCatch = false;
+    for (let j = i + 1; j < lines.length && j < i + 40; j += 1) {
+      if (/^\s*\} catch/.test(lines[j]!)) {
+        hasCatch = true;
+        break;
+      }
+    }
+    if (hasCatch) offenders.push(`app.ts:${i + 1} ${method}`);
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `these returns skip their own catch — add \`await\`:\n${offenders.join("\n")}`,
+  );
+});

--- a/runtime/api-server/src/runtime-agent-tools.test.ts
+++ b/runtime/api-server/src/runtime-agent-tools.test.ts
@@ -4475,7 +4475,7 @@ test("updateWorkspaceInstructions replaces and clears the managed AGENTS.md sect
   }
 });
 
-test("installCapability tool installs a workspace-authored capability", () => {
+test("installCapability tool installs a workspace-authored capability", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "hb-cap-tool-"));
   writeRuntimeConfig(root, { runtime: { default_model: "openai/gpt-5.4" } });
   const workspaceRoot = path.join(root, "workspace");
@@ -4489,7 +4489,10 @@ test("installCapability tool installs a workspace-authored capability", () => {
       "id: demo-cap\nname: Demo\ndescription: d\nversion: 0.1.0\nskills:\n  - ref: demo-skill\nintegrations: []\n", "utf8");
 
     const service = new RuntimeAgentToolsService(store, { workspaceRoot });
-    const result = service.installCapability({ workspaceId, capabilityId: "demo-cap" }) as Record<string, unknown>;
+    const result = (await service.installCapability({
+      workspaceId,
+      capabilityId: "demo-cap",
+    })) as Record<string, unknown>;
 
     assert.ok(result.record);
     assert.equal(store.getWorkspaceCapability({ workspaceId, capabilityId: "demo-cap" })?.name, "Demo");

--- a/runtime/api-server/src/runtime-agent-tools.ts
+++ b/runtime/api-server/src/runtime-agent-tools.ts
@@ -7604,13 +7604,19 @@ export class RuntimeAgentToolsService {
     return !childSession?.archivedAt;
   }
 
-  installCapability(params: RuntimeAgentToolsInstallCapabilityParams): JsonObject {
+  // Async: installWorkspaceAuthoredCapability returns a promise. This was
+  // declared sync and laundered the promise through `as unknown as JsonObject`,
+  // so the type checker could not see it — any caller that did not happen to
+  // await got a promise where it expected the install result.
+  async installCapability(
+    params: RuntimeAgentToolsInstallCapabilityParams,
+  ): Promise<JsonObject> {
     this.requireWorkspace(params.workspaceId);
     const capabilityId = normalizedString(params.capabilityId);
     if (!capabilityId) {
       throw new RuntimeAgentToolsServiceError(400, "capability_id_required", "capabilityId is required");
     }
-    const result = installWorkspaceAuthoredCapability({
+    const result = await installWorkspaceAuthoredCapability({
       store: this.store,
       workspaceId: params.workspaceId,
       workspaceDir: this.store.workspaceDir(params.workspaceId),

--- a/runtime/api-server/src/workspace-apps.ts
+++ b/runtime/api-server/src/workspace-apps.ts
@@ -479,11 +479,23 @@ export function listWorkspaceApplications(workspaceDir: string): Array<Record<st
   return Array.isArray(document.applications) ? document.applications.filter(isRecord) : [];
 }
 
+/**
+ * Every MCP server name in the workspace registry, across BOTH sections.
+ *
+ * App-owned servers live in `mcp_registry.app_servers`, and
+ * `writeWorkspaceMcpRegistryEntry` deliberately drops the legacy `servers` copy
+ * when it writes one. Reading only `servers` therefore made every
+ * app-container server invisible here — which silently broke the
+ * new-server diff that drives `requires_session_refresh`: installing an app
+ * never flagged the session, so the agent kept running without the app's tools
+ * until something else forced a refresh.
+ */
 export function readWorkspaceMcpRegistryServerNames(workspaceDir: string): Set<string> {
   const document = readWorkspaceYamlDocument(workspaceDir);
   const registry = isRecord(document.mcp_registry) ? document.mcp_registry : {};
   const servers = isRecord(registry.servers) ? registry.servers : {};
-  return new Set(Object.keys(servers));
+  const appServers = isRecord(registry.app_servers) ? registry.app_servers : {};
+  return new Set([...Object.keys(servers), ...Object.keys(appServers)]);
 }
 
 export interface WorkspaceMcpServerSummary {

--- a/runtime/api-server/src/workspace-capabilities.test.ts
+++ b/runtime/api-server/src/workspace-capabilities.test.ts
@@ -444,7 +444,9 @@ test("import-plugin: throws when there is no plugin manifest", async () => {
   const { store, root } = makeStore();
   const workspaceDir = path.join(root, "workspace", "ws-import-2");
   const emptyDir = makeTempDir("hb-plugin-empty-");
-  assert.throws(
+  // importPluginAsCapability is async, so the rejection has to be awaited —
+  // assert.throws() on the un-awaited call can never observe it.
+  await assert.rejects(
     () =>
       importPluginAsCapability({
         store,


### PR DESCRIPTION
## Summary

Three real bugs, all caught by tests that **already existed and were already correct** — they had simply never run. See "Why nobody noticed" below.

### 1. Installing an app never flags the session to refresh

`readWorkspaceMcpRegistryServerNames` (`workspace-apps.ts:482`) read only `mcp_registry.servers`. But `writeWorkspaceMcpRegistryEntry` writes app-owned servers to `mcp_registry.app_servers` (`workspace-apps.ts:858`) and *deliberately drops* the legacy `servers` copy (`:843`, "Drop any legacy standalone-pool copy of this app's server (pre-app_servers)").

So app MCP servers were invisible to the before/after diff at `runtime-agent-tools.ts:8806`. `newMcpServers` came back empty, and `buildSessionRefreshFields` returns `{}` for an empty list — so `requires_session_refresh` was never set.

**User-visible:** you install an app, and the agent is never told to pick up its tools. They stay missing until something else forces a refresh. This is the "I installed it but the agent can't use it" symptom.

The fix is to read both sections. All five call sites want "every MCP server in this workspace", so widening is correct for each.

### 2. `RuntimeAgentToolsService.installCapability` was a sync function returning a promise

It was declared `: JsonObject` while calling the **async** `installWorkspaceAuthoredCapability`, and returned `result as unknown as JsonObject`. That cast is precisely what kept `tsc` quiet about it. Any caller that did not already happen to `await` got a promise where it expected the install result.

### 3. `POST /api/v1/capabilities/install` did not await

`app.ts:12053` called the async `installCapability` without `await` and passed the pending promise to `reply.send` — serialized as `{}`, and responded **before the install had finished**.

Plus a test that could never have failed: it asserted an async rejection using `assert.throws` on the un-awaited call, so `Missing expected exception` was the only possible outcome.

## Why nobody noticed

`runtime/api-server`'s `test` script is `node --import tsx --test --test-force-exit src/**/*.test.ts` — **unquoted**. api-server is the only runtime package with *nested* test files, so bun's shell expands the glob to just those 2 and hands them to node, shadowing node's own recursive expansion.

```
unquoted   →   13 tests   (2 files)
quoted     → 1106 tests   (113 files)
```

The `runtime-api-server` CI job *does* run this suite — so CI has been reporting green on 13 tests all along. (An earlier version of this description wrongly said api-server was not covered by CI at all; it is. The glob is the whole story here.) Separately, `runtime-harnesses` and `runtime-channel-gateway` both have `test` scripts but appear in no CI filter, so they genuinely never run — which is why a stale assertion in `harnesses/src/pi.test.ts` has gone unnoticed.

Both are fixed in a follow-up PR; this one is deliberately just the bugs, so it can be reviewed on its merits. The remaining stale expectations in that suite are also separate.

## Risks

- Widening `readWorkspaceMcpRegistryServerNames` also widens `refreshMcpTools`'s reported `servers` list — correct, since the pi tool cache it invalidates is workspace-wide and already covers app servers.
- Making `installCapability` async is a signature change. `tsc --noEmit` is clean, and its one production caller (`app.ts:8120`) returns it straight out of an `async` Fastify handler, which awaits it — so that path was already fine at runtime.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `runtime-agent-tools.test.ts` 52/52, `workspace-capabilities.test.ts` 16/16, `workspace-capabilities-routes.test.ts` 1/1
- [x] Fixing (1) alone turned **3 red tests green with no test edits** — the strongest evidence the tests were right and the code drifted out from under them
- [x] Full api-server suite (quoted glob): 1103 tests, 1087 pass. The 13 remaining failures are in `app.test.ts` and `claimed-input-executor.test.ts` and are untouched by this PR.

## Docs

- [ ] n/a — no setup, packaging, or public API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
