### PR TITLE
fix(runtime): load pi's session-manager as ESM, not via createRequire

### DIFF
--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, test as nodeTest } from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   RuntimeStateStore,
@@ -62,7 +61,6 @@ const ORIGINAL_ENV = {
   HOLABOSS_RUNTIME_CONFIG_PATH: process.env.HOLABOSS_RUNTIME_CONFIG_PATH,
   HOLABOSS_HARNESS_RUN_TIMEOUT_S: process.env.HOLABOSS_HARNESS_RUN_TIMEOUT_S,
 };
-const require = createRequire(import.meta.url);
 const PI_PACKAGE_ENTRY_PATH = fileURLToPath(
   import.meta.resolve("@earendil-works/pi-coding-agent"),
 );
@@ -70,6 +68,14 @@ const PI_SESSION_MANAGER_MODULE_PATH = path.join(
   path.dirname(PI_PACKAGE_ENTRY_PATH),
   "core",
   "session-manager.js",
+);
+// Imported, not require()d: session-manager.js pulls in
+// @earendil-works/pi-agent-core, whose "." export declares only an `import`
+// condition. Reaching it through createRequire therefore fails with
+// ERR_PACKAGE_PATH_NOT_EXPORTED. Loaded once here so the helpers below can
+// stay synchronous.
+const PI_SESSION_MANAGER_MODULE = await import(
+  pathToFileURL(PI_SESSION_MANAGER_MODULE_PATH).href
 );
 
 function test(
@@ -269,7 +275,7 @@ function writeWorkspaceSkill(
 }
 
 function openPiSessionManager(sessionFile: string) {
-  const { SessionManager } = require(PI_SESSION_MANAGER_MODULE_PATH) as {
+  const { SessionManager } = PI_SESSION_MANAGER_MODULE as {
     SessionManager: {
       create: (cwd: string, sessionDir?: string) => {
         appendMessage: (message: Record<string, unknown>) => string;
@@ -312,7 +318,7 @@ function createPiSessionFile(params: {
   sessionDir: string;
 }) {
   fs.mkdirSync(params.sessionDir, { recursive: true });
-  const { SessionManager } = require(PI_SESSION_MANAGER_MODULE_PATH) as {
+  const { SessionManager } = PI_SESSION_MANAGER_MODULE as {
     SessionManager: {
       create: (cwd: string, sessionDir?: string) => {
         appendMessage: (message: Record<string, unknown>) => string;
@@ -1280,7 +1286,9 @@ test("claimed input creates a completion notification for completed main-session
   // Single-tenant: the claimed input resolves to the canonical root workspace,
   // whose registry row is folded away by consolidation, so the notification
   // sourceLabel falls back to the synthetic root's default name "Workspace".
-  assert.equal(notifications[0]?.title, "Workspace — Reply ready");
+  // The seed above names this workspace "Workspace 1"; bare "Workspace" is only
+  // the fallback for an empty name.
+  assert.equal(notifications[0]?.title, "Workspace 1 — Reply ready");
   assert.equal(notifications[0]?.message, "Hello from the main session.");
   assert.equal(notifications[0]?.level, "info");
   assert.equal(notifications[0]?.sourceType, "main_session");

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -2,8 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type {
   AgentSessionRecord,
@@ -315,16 +314,29 @@ function nonEmptyString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
-const require = createRequire(import.meta.url);
+/**
+ * pi's session-manager is ESM, and it pulls in @earendil-works/pi-agent-core,
+ * whose "." export declares only an `import` condition. Loading it through
+ * createRequire happens to work under plain node, but tsx's CJS resolver walks
+ * that graph with require conditions and fails with
+ * ERR_PACKAGE_PATH_NOT_EXPORTED -- which took out every code path below
+ * (session snapshots, leaf state, provider-termination recovery) whenever the
+ * runtime ran under tsx, i.e. the test suite and the `hola` CLI.
+ *
+ * Loaded once here as ESM so every caller can stay synchronous.
+ */
+const PI_SESSION_MANAGER_MODULE = (await import(
+  pathToFileURL(PI_SESSION_MANAGER_MODULE_PATH).href
+)) as {
+  SessionManager: PiSessionManagerStatic;
+  getLatestCompactionEntry: GetLatestPiCompactionEntryFn;
+};
 
 function loadPiSessionManagerModule(): {
   SessionManager: PiSessionManagerStatic;
   getLatestCompactionEntry: GetLatestPiCompactionEntryFn;
 } {
-  return require(PI_SESSION_MANAGER_MODULE_PATH) as {
-    SessionManager: PiSessionManagerStatic;
-    getLatestCompactionEntry: GetLatestPiCompactionEntryFn;
-  };
+  return PI_SESSION_MANAGER_MODULE;
 }
 
 function resolvePiLiveSessionDir(workspaceDir: string): string {

--- a/runtime/api-server/src/session-checkpoint.ts
+++ b/runtime/api-server/src/session-checkpoint.ts
@@ -1,9 +1,8 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type { PostRunJobRecord, RuntimeStateStore } from "@holaboss/runtime-state-store";
 
@@ -117,7 +116,6 @@ export interface ForceSessionCompactionResult {
   strippedTrailingCompactions: number;
 }
 
-const require = createRequire(import.meta.url);
 const PI_PACKAGE_ENTRY_PATH = fileURLToPath(
   import.meta.resolve("@earendil-works/pi-coding-agent"),
 );
@@ -126,14 +124,21 @@ const PI_SESSION_MANAGER_MODULE_PATH = path.join(
   "core",
   "session-manager.js",
 );
+// Loaded as ESM, not via createRequire: see the note in
+// claimed-input-executor.ts. pi-agent-core exposes only an `import` condition,
+// and tsx's CJS resolver throws ERR_PACKAGE_PATH_NOT_EXPORTED walking to it.
+const PI_SESSION_MANAGER_MODULE = (await import(
+  pathToFileURL(PI_SESSION_MANAGER_MODULE_PATH).href
+)) as {
+  SessionManager: PiSessionManagerStatic;
+  getLatestCompactionEntry: GetLatestCompactionEntryFn;
+};
+
 function loadPiSessionManagerModule(): {
   SessionManager: PiSessionManagerStatic;
   getLatestCompactionEntry: GetLatestCompactionEntryFn;
 } {
-  return require(PI_SESSION_MANAGER_MODULE_PATH) as {
-    SessionManager: PiSessionManagerStatic;
-    getLatestCompactionEntry: GetLatestCompactionEntryFn;
-  };
+  return PI_SESSION_MANAGER_MODULE;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

`session-checkpoint.ts` and `claimed-input-executor.ts` both loaded pi's `core/session-manager.js` through `createRequire`. That module imports `@earendil-works/pi-agent-core`, whose `"."` export declares only an `import` condition — no `require`:

```json
".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
```

Under plain node this happens to resolve (verified both `require()` and `import()` succeed there). **Under tsx it does not** — tsx's CJS resolver walks the graph with require conditions and throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. tsx is how the test suite and the `hola` CLI run, so every path through these loaders was dead in both.

Each module now imports the ESM module once at module scope and hands it to the existing synchronous accessor, so **no call site changes**. The api-server bundles as ESM (`tsup format: ["esm"]`), so top-level await is fine.

## The symptom this was causing

Provider-termination recovery never ran. The throw came out of `currentPiSessionLeafState` *before* the compaction call and was swallowed upstream, so a long-running run terminated by the provider just failed — instead of compacting the session and retrying. Both `retries long-running terminated PI … runs after snapshot compaction` tests were reporting `compactionCalls = 0`.

I traced it by probe rather than assumption, in this order: payload reaches the predicate → predicate returns `true` → recovery block is entered → `liveSessionState` throws. The stack pointed at `tsx/dist/register-*`, which is what identified tsx rather than the package as the discriminator.

## Scope note — this is not a production outage

I initially suspected a shipped bug and checked before writing it up: under plain node, **both** `require()` and `import()` of that path succeed. So packaged runtime behaviour is unaffected. What was broken is everything that runs under tsx — the test suite and `hola` — plus the latent fragility of using `createRequire` on an ESM-only dependency from an ESM module.

## Also in here

The test file used the same `createRequire` pattern and needed the same change. While there, one stale assertion in it is corrected: the notification-title test expected `"Workspace — Reply ready"` while seeding a workspace named `"Workspace 1"` — bare `"Workspace"` is only the empty-name fallback (`claimed-input-executor.ts:2518`).

## Risks

- Top-level await in two modules. Both are ESM-only by build config; nothing requires them from CJS.
- The loaded module object is now cached process-wide rather than per-call. It was already effectively cached by the require cache, so this is not a behaviour change.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `claimed-input-executor.test.ts`: 7 failures → 2 (the 2 remaining are unrelated assertions, being handled separately)
- [x] Full api-server suite (quoted glob): 1103 tests, **1092 pass**, 8 fail — down from 24 failures when I started. The 8 are in `app.test.ts` (6, mostly durable-memory routes) and `claimed-input-executor.test.ts` (2), all untouched by this PR.
- [x] Verified `require()` vs `import()` under plain node to confirm the production path is unaffected

**Stacked on #479** — this branch was cut from that one, so it must merge after it. Base is set to `fix/runtime-mcp-refresh-and-async-bugs` so the diff here shows only the 3 files this PR actually changes. (An earlier version of this line said the two were independent with no file overlap; that was wrong — #480 contains #479's commits.)

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
