### PR TITLE
test(runtime): unrot api-server expectations that outlived their decisions

### DIFF
--- a/runtime/api-server/src/agent-runtime-prompt.test.ts
+++ b/runtime/api-server/src/agent-runtime-prompt.test.ts
@@ -218,7 +218,14 @@ test("composeBaseAgentPrompt returns ordered runtime prompt layers", () => {
   assert.doesNotMatch(prompt.systemPrompt, /Connected MCP tools available now:/);
   assert.doesNotMatch(prompt.systemPrompt, /Skills available now:/);
   assert.doesNotMatch(prompt.systemPrompt, /Connected MCP access: available\./);
-  assert.ok(prompt.systemPrompt.length < 6500);
+  // Budget guard on the base system prompt, which is paid on every single turn.
+  // It drifted past the old 6500 ceiling (measured 6782) while this file was
+  // not being run by CI — see the test-glob fix that turns this suite on. Raised
+  // to a round 7000 rather than deleted: the point is to notice growth.
+  assert.ok(
+    prompt.systemPrompt.length < 7000,
+    `base system prompt grew to ${prompt.systemPrompt.length} chars`,
+  );
   assert.equal(prompt.contextMessages.length, 1);
   assert.match(prompt.contextMessages.join("\n\n"), /Capability availability snapshot:/);
   assert.match(prompt.contextMessages.join("\n\n"), /Inspect tools: available \(\d+ enabled\)\./);

--- a/runtime/api-server/src/image-generation-model.test.ts
+++ b/runtime/api-server/src/image-generation-model.test.ts
@@ -285,7 +285,12 @@ test("image generation model client routes managed Holaboss Gemini image models 
   assert.deepEqual(client, {
     baseUrl: "https://runtime.example/api/v1/model-proxy/google/v1",
     apiKey: "hb-token",
-    defaultHeaders: { "X-Holaboss-User-Id": "user-xyz" },
+    defaultHeaders: {
+      "X-Holaboss-User-Id": "user-xyz",
+      // Added so desktop image spend is attributed in the usage log's Entity
+      // column; without it that column is blank.
+      "X-Holaboss-Requester-Id": "desktop:user-xyz",
+    },
     modelId: "gemini-3.1-flash-image",
     apiStyle: "openai_compatible",
   });

--- a/runtime/api-server/src/ts-runner.test.ts
+++ b/runtime/api-server/src/ts-runner.test.ts
@@ -366,6 +366,8 @@ test("decodeTsRunnerRequest decodes a valid runner request", () => {
     agent_cwd: null,
     session_id: "session-1",
     session_kind: null,
+    // Defaulted by the decoder; absent from the encoded input above.
+    harness_timeout_seconds: 0,
     input_id: "input-1",
     instruction: "hello",
     attachments: [],
@@ -1328,8 +1330,12 @@ test("runTsRunnerCli only advertises structured output when the selected harness
       {},
   ).sort();
   assert.deepEqual(bootstrapStageTimingKeys, [
+    // The two composio stages arrived with the cross-process inline-tools
+    // cache; this list predates it.
+    "await_composio_inline_tools",
     "build_harness_host_request",
     "compile_runtime_plan",
+    "composio_inline_tools_fetch",
     "load_current_user_context",
     "load_operator_surface_context",
     "load_pending_user_memory_context",
@@ -2315,7 +2321,7 @@ test("runTsRunnerCli projects prior attachment turns into session attachment con
   });
 });
 
-test("runTsRunnerCli does not inject report-routing recovery context for main-session requests (full-capability surface)", async () => {
+test("runTsRunnerCli never advertises a staged runtime tool that is in the hidden set", async () => {
   const sandboxRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), "hb-ts-runner-report-routing-"),
   );
@@ -2395,9 +2401,12 @@ test("runTsRunnerCli does not inject report-routing recovery context for main-se
     throw new Error("expected project runtime config request");
   }
   const runtimeConfigRequest = capturedProjectRequest as AgentRuntimeConfigCliRequest;
-  assert.deepEqual(runtimeConfigRequest.runtime_tool_ids, [
-    "delegate_task",
-  ]);
+  // A staged tool in HIDDEN_RUNTIME_TOOL_IDS must never reach the model. The
+  // hidden set exists so a tool can stay wired end-to-end while being
+  // unadvertised, and `delegate_task` is in it "while delegation is paused" —
+  // so staging it above and getting nothing back is the invariant, not a
+  // regression. Empty the hidden set to re-enable and this flips.
+  assert.deepEqual(runtimeConfigRequest.runtime_tool_ids, []);
 });
 
 test("runTsRunnerCli does not inject available-tool fallback context for main-session concrete checks (full-capability surface)", async () => {


### PR DESCRIPTION
## Summary

Five assertions that pinned behaviour the product has since changed. **None of these is a bug** — each encodes a decision that was later reversed or extended, and none was noticed because the suite barely runs (13 of 1106 tests; see the glob issue below).

| File | What drifted |
|---|---|
| `ts-runner.test.ts` | `decodeTsRunnerRequest` gained `harness_timeout_seconds` |
| `ts-runner.test.ts` | Bootstrap stage list gained `await_composio_inline_tools` + `composio_inline_tools_fetch` with the composio inline-tools cache |
| `ts-runner.test.ts` | A test named for "report-routing recovery context" — a concept that no longer exists anywhere in the tree |
| `agent-runtime-prompt.test.ts` | Base system prompt outgrew its 6500-char budget (measured **6782**) |
| `image-generation-model.test.ts` | Gained `X-Holaboss-Requester-Id`, added so desktop image spend is attributed in the usage log's Entity column |

## Two judgement calls worth flagging

**The prompt budget.** I raised it to a round 7000 rather than deleting the assertion, and recorded the measured value in the message. That prompt is paid on *every* turn, so the guard earns its keep — it only drifted because nothing ran it. If 6782 is considered too big, that's a separate conversation this PR deliberately doesn't pre-empt.

**The fossil test.** `runTsRunnerCli does not inject report-routing recovery context…` had a name referring to nothing that exists, and its sole assertion was that a staged `delegate_task` reaches `runtime_tool_ids`. But `delegate_task` now sits in `HIDDEN_RUNTIME_TOOL_IDS` ("Currently hides the subagent delegation family … while delegation is paused"), so `[]` is the correct expectation. Rather than delete it or silently flip the number, I renamed it to what it actually guards — **a staged tool in the hidden set is never advertised** — which is a live invariant. Emptying that set to re-enable delegation will flip it back, and the comment says so.

## State of the suite

Running the api-server suite with a *quoted* glob (so node expands it recursively):

```
when I started   1103 tests, 24 fail
after this PR    1103 tests,  8 fail
```

(An earlier version of this description said 3. That was an arithmetic slip on my part — the run I was comparing against already included this PR's three files.)

The remaining 8, all triaged and none blocking this PR:

- **`app.test.ts` — 4 memory-route tests**: these assert per-turn model extraction of durable memory, which was **retired on 2026-07-14** in favour of the agent-invoked `remember` tool. `turn-memory-writeback.ts:568` states it outright, and `docs/plans/2026-07-14-agent-invoked-durable-memory.md` is the design. Two of them also assert artifact provenance, which *is* still live — so they need per-test surgery to keep the good half rather than wholesale deletion. Deliberately not rushed into this PR.
- **`app.test.ts` — 2 more**: OpenRouter image generation, and app-lifecycle uninstall. Not yet classified.
- **`claimed-input-executor.test.ts` — 2**: delegated-subagent artifact discoverability (likely the same retired-memory story), and a duplicate-artifact assertion. Not yet classified.

## Why the suite barely runs

`runtime/api-server`'s `test` script uses an **unquoted** `src/**/*.test.ts`. api-server is the only runtime package with nested test files, so bun's shell expands the glob to just those 2 and hands them to node, shadowing node's own recursive expansion — 13 tests instead of 1106. Separately, `runtime-harnesses` and `runtime-channel-gateway` have `test` scripts but appear in no CI filter at all.

The one-line fix for that is held back deliberately until the suite is green, so it can't land red. It's the last PR in this stack.

## Validation

- [x] `ts-runner.test.ts` 61/61, `agent-runtime-prompt.test.ts` 22/22, `image-generation-model.test.ts` 9/9
- [x] `bun run typecheck` (api-server) — clean
- [x] No source files touched — tests only

**Stacked on #480** (which is stacked on #479). Base is set accordingly so the diff shows only this PR's 3 files.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
