### PR TITLE
fix(desktop): bound main-process fetches so a hung backend can't wedge the UI

### DIFF
--- a/apps/desktop/electron/main-fetch-timeouts.test.mjs
+++ b/apps/desktop/electron/main-fetch-timeouts.test.mjs
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+/**
+ * Node's fetch has no default timeout. A backend that accepts the connection
+ * but never responds therefore leaves the caller pending for undici's ~300s
+ * headersTimeout, which reaches the user as a spinner that never resolves and
+ * never errors. These guards pin the two places where that was worst.
+ */
+
+test("the shared main-process fetch helper bounds every attempt", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(source, /const MAIN_FETCH_TIMEOUT_MS = /);
+
+  const helper = source.slice(
+    source.indexOf("async function fetchWithNetworkRetry"),
+  );
+  const body = helper.slice(0, helper.indexOf("\n}\n") + 3);
+
+  assert.match(
+    body,
+    /AbortSignal\.timeout\(MAIN_FETCH_TIMEOUT_MS\)/,
+    "fetchWithNetworkRetry no longer applies a timeout",
+  );
+  // A caller-supplied signal must be combined with the deadline, not dropped —
+  // otherwise an explicit shorter timeout or a cancellation stops working.
+  assert.match(
+    body,
+    /AbortSignal\.any\(\[callerSignal, timeoutSignal\]\)/,
+    "caller signal is no longer combined with the timeout",
+  );
+  // Both the first attempt and the retry must build their own signal; sharing
+  // one hands the retry an already-aborted deadline.
+  assert.equal(
+    body.match(/initWithDeadline\(\)/g)?.length,
+    2,
+    "both the first attempt and the retry must build their own deadline",
+  );
+});
+
+test("the session lookup that gates the shell is bounded", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  // Anchor on the call itself: the path also appears in a nearby comment.
+  const index = source.indexOf("fetch(`${AUTH_BASE_URL}/api/auth/get-session`");
+  assert.notEqual(index, -1, "get-session request not found in main.ts");
+  // RequireAuth holds the whole shell on this promise, so an unanswered
+  // request here is a permanent boot splash with no error path.
+  const request = source.slice(index, index + 400);
+  assert.match(
+    request,
+    /signal: AbortSignal\.timeout\(/,
+    "the get-session request no longer carries a timeout",
+  );
+});
+
+test("the streaming employee-chat request is deliberately left unbounded", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  // Counterpart to the guards above: an SSE response is long-lived by design,
+  // so blanket-applying the request timeout to it would cut live streams off.
+  const index = source.indexOf("Accept: \"text/event-stream\"");
+  assert.notEqual(index, -1, "employee chat stream request not found");
+  const request = source.slice(index - 400, index + 400);
+  assert.doesNotMatch(
+    request,
+    /AbortSignal\.timeout\(MAIN_FETCH_TIMEOUT_MS\)/,
+    "the SSE stream must not inherit the request/response timeout",
+  );
+});

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8498,11 +8498,16 @@ async function getAuthenticatedUser(): Promise<AuthUserPayload | null> {
   const startedAt = Date.now();
   let response: Response;
   try {
+    // Bounded deliberately: RequireAuth holds the entire shell on this
+    // promise, so an unanswered request here is a permanent boot splash with
+    // no error path — a captive portal or a slow api host, not just an
+    // offline one. Failing is recoverable; hanging is not.
     response = await fetch(`${AUTH_BASE_URL}/api/auth/get-session`, {
       method: "GET",
       headers: {
         Cookie: cookieHeader,
       },
+      signal: AbortSignal.timeout(MAIN_FETCH_TIMEOUT_MS),
     });
   } catch (error) {
     logBffFetch({
@@ -9530,20 +9535,53 @@ function isTransientFetchError(err: unknown): boolean {
 }
 
 /**
- * Wraps fetch with a single retry against transient network errors.
+ * Ceiling on any main-process request/response fetch.
+ *
+ * Node's fetch has no default timeout, so a backend that accepts the TCP
+ * connection but never answers — the common hung-upstream failure, as opposed
+ * to a refusal, which fails fast — leaves the renderer's promise pending for
+ * undici's 300s headersTimeout. That surfaces as a spinner that never resolves
+ * and never errors. 20s is well above any healthy call here and well below the
+ * point where a user has concluded the app is broken.
+ */
+const MAIN_FETCH_TIMEOUT_MS = 20_000;
+
+/**
+ * Wraps fetch with a single retry against transient network errors, under a
+ * bounded timeout.
+ *
  * Backoff is short (200ms) because keep-alive socket races resolve as
  * soon as a fresh connection is opened. Auth/HTTP-level failures (4xx,
  * 5xx) are returned untouched — those go through retryAfterSessionAuth.
+ *
+ * A caller-supplied signal still wins: it is combined with the timeout rather
+ * than replaced, so an explicit shorter deadline (or a cancellation) is
+ * honoured. Timeouts are not retried — `isTransientFetchError` only matches
+ * TypeErrors from undici, and an abort raises TimeoutError — so a stalled
+ * upstream costs one timeout, not two.
  */
 async function fetchWithNetworkRetry(
   ...args: Parameters<typeof fetch>
 ): Promise<Response> {
+  const [input, init] = args;
+  const callerSignal = init?.signal ?? null;
+  // Built per attempt: reusing one signal would hand the retry an
+  // already-aborted deadline.
+  const initWithDeadline = (): RequestInit => {
+    const timeoutSignal = AbortSignal.timeout(MAIN_FETCH_TIMEOUT_MS);
+    return {
+      ...init,
+      signal: callerSignal
+        ? AbortSignal.any([callerSignal, timeoutSignal])
+        : timeoutSignal,
+    };
+  };
   try {
-    return await fetch(...args);
+    return await fetch(input, initWithDeadline());
   } catch (err) {
     if (!isTransientFetchError(err)) throw err;
     await new Promise((resolve) => setTimeout(resolve, 200));
-    return fetch(...args);
+    return fetch(input, initWithDeadline());
   }
 }
 
@@ -29123,6 +29161,10 @@ app.whenReady().then(async () => {
         const res = await fetch(url, {
           method: "GET",
           headers: cookie ? { Cookie: cookie } : undefined,
+          // This runs while the user types a name. The fallback below is the
+          // intended behaviour on a bad backend, but without a deadline it was
+          // unreachable for undici's full 300s.
+          signal: AbortSignal.timeout(5_000),
         });
         if (!res.ok) {
           // Endpoint not ready — fall back to "available" so UI doesn't block.


### PR DESCRIPTION
## Summary

Node's `fetch` has no default timeout, and `rg -c 'AbortSignal.timeout' main.ts` returned **0** against 16 fetch call sites. A backend that accepts the TCP connection but never answers — the common hung-upstream failure, as opposed to a refusal, which fails fast — left the renderer's promise pending for undici's ~300s `headersTimeout`. `fetchWithNetworkRetry` doubled that by retrying without a signal.

## The case that matters most

`RequireAuth` holds the **entire shell** on the `/api/auth/get-session` promise. Because the socket hangs rather than rejects, there is no error path — nothing downstream can even report a failure. The user gets a boot splash, indefinitely.

It is on every launch: the renderer's `cachedAuthUser` is a module-scope variable and main's `cachedAuthSession` has a 10s TTL, so neither survives a cold start. A captive portal, a VPN, or a slow `api.holaos.ai` is enough to trigger it.

## What changed

| Call site | Deadline |
|---|---|
| `fetchWithNetworkRetry` (5 call sites) | `MAIN_FETCH_TIMEOUT_MS` = 20s, **per attempt** |
| `/api/auth/get-session` | same 20s ceiling |
| `checkTemplateName` (runs while the user types) | 5s |

Two details worth reviewing:

- A caller-supplied signal is **combined** via `AbortSignal.any`, not replaced — so the existing 6s controller at the runtime-probe call site still wins, and cancellations keep working.
- Each attempt builds its own signal. Sharing one would hand the retry an already-aborted deadline.

`checkTemplateName`'s `"endpoint not ready"` fallback was already the intended behaviour on a bad backend — it was simply unreachable for 300s.

## Deliberately left unbounded

- **The employee-chat SSE request** (`Accept: text/event-stream`) is long-lived by design. A blanket timeout would cut live streams off mid-response. There is a third guard test pinning this exclusion so a later well-meaning sweep can't break it.
- **Large media downloads** (`/gateway/hub/public/...`). A whole-request deadline is the wrong shape there; a slow-body/idle timeout would be, but that is a different change.

## Not a blind sweep

Three sibling paths already do this correctly — `bff-fetch.ts:118` (30s controller), the model-catalogue fetch (8s), and the app-surface load race (`WEB_HOLAAPP_LOAD_TIMEOUT_MS`). This is local inconsistency, not a missing concept; the direct callers in `main.ts` were never brought up to that bar.

## Timeouts are not retried

`isTransientFetchError` requires `err instanceof TypeError` (undici network errors), and an abort raises `TimeoutError`. So a stalled upstream costs one timeout, not two. I checked this specifically before adding the deadline inside the retry helper.

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 122/122 (119 existing + 3 new)
- [x] All three new guards **mutation-verified**: removing the helper's timeout fails one, removing the get-session signal fails another. My first draft of the guards was wrong in two ways (counted an arrow-const declaration as a call site, and matched the `get-session` path inside a comment rather than the call) — both corrected before committing.
- [ ] `npm run runtime:test` — not run; this PR touches no runtime code.

## Docs

- [ ] n/a — no setup, packaging, or public API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)