### PR TITLE
fix(desktop): make main-process crashes visible in packaged builds

### DIFF
--- a/apps/desktop/electron/crash-visibility.test.mjs
+++ b/apps/desktop/electron/crash-visibility.test.mjs
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+/**
+ * Registering an `uncaughtException` listener suppresses Electron's own error
+ * dialog and its non-zero exit, so these handlers ARE the entire crash story
+ * for the main process. A packaged app has no terminal, so a handler that only
+ * reaches console leaves every production crash invisible.
+ */
+
+test("main-process crashes are recorded somewhere a packaged build can surface", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  assert.match(
+    source,
+    /process\.on\("uncaughtException"/,
+    "the uncaughtException handler is gone",
+  );
+  assert.match(
+    source,
+    /process\.on\("unhandledRejection"/,
+    "the unhandledRejection handler is gone",
+  );
+
+  const handler = source.slice(
+    source.indexOf("function recordMainProcessCrash"),
+  );
+  const body = handler.slice(0, handler.indexOf("\n}\n") + 3);
+  assert.ok(body.length > 0, "recordMainProcessCrash not found");
+
+  // console alone is not a crash record in a packaged app. runtime.log is what
+  // the diagnostics bundle collects, so it is the one destination that makes a
+  // shipped crash recoverable after the fact.
+  assert.match(
+    body,
+    /appendRuntimeLog\(/,
+    "crashes no longer reach runtime.log, so packaged crashes are invisible again",
+  );
+
+  // Both handlers must route through it — an inlined console.error in either
+  // one is the regression this guards.
+  const crashBlock = source.slice(
+    source.indexOf("function recordMainProcessCrash"),
+    source.indexOf('process.on("unhandledRejection"') + 400,
+  );
+  assert.equal(
+    crashBlock.match(/recordMainProcessCrash\(/g)?.length,
+    3,
+    "expected recordMainProcessCrash to be declared once and called by both handlers",
+  );
+});
+
+test("EPIPE stays suppressed and everything else does not", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+  const index = source.indexOf('process.on("uncaughtException"');
+  const handler = source.slice(index, index + 400);
+
+  // EPIPE on stdio writes is a benign teardown race Electron would otherwise
+  // show as an error modal. It is the ONLY thing that may be swallowed.
+  assert.match(handler, /err\?\.code === "EPIPE"/);
+  assert.match(handler, /recordMainProcessCrash\("uncaughtException", err\)/);
+});

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -70,31 +70,56 @@ function initialDesktopAppName(): string {
 electronApp.setName(initialDesktopAppName());
 
 
-// Swallow EPIPE on stdio writes — a benign teardown race that Electron
-// would otherwise surface as a "Holaboss encountered an error" modal.
-// Trigger: a child / utility process (or the embedded runtime) writes via
-// `console.info`/`.warn`/`.error` after its stdio pipe has been closed on
-// the parent side. Sentry's `consoleLoggingIntegration` above wraps those
-// console methods and re-invokes the real ones, so the EPIPE surfaces here
-// with a stack that ends in `sentry/core/build/cjs/instrument/console.js`
-// — not actually a Sentry bug, just an unhandled write to a half-closed
-// socket. Anything other than EPIPE we leave alone so the existing Sentry
-// + Electron handlers still see it.
-process.on("uncaughtException", (err: NodeJS.ErrnoException) => {
-  if (err?.code === "EPIPE") return;
-});
-
-// The handler above deliberately swallows EPIPE (and, historically, everything
-// else) without logging — which hides real main-process crashes. Log anything
-// non-EPIPE so failures (e.g. window teardown) are visible in the terminal.
-process.on("uncaughtException", (err: NodeJS.ErrnoException) => {
-  if (err?.code === "EPIPE") return;
+/**
+ * Main-process crash visibility.
+ *
+ * Registering an `uncaughtException` listener suppresses Electron's own error
+ * dialog and its non-zero exit, so whatever these handlers do IS the entire
+ * crash story. Previously that was a bare `console.error`, which a packaged
+ * app has nowhere to show: every production main-process crash was invisible,
+ * and the process carried on in a half-broken state.
+ *
+ * There is no crash reporter behind this. Earlier comments here described
+ * Sentry's `consoleLoggingIntegration` and "the existing Sentry + Electron
+ * handlers" as if they were catching the rest; no `@sentry/*` dependency has
+ * ever been in this package, `crashReporter` is never started, and the
+ * renderer registers no `onerror`. Those comments have been removed rather
+ * than left to reassure the next reader.
+ *
+ * So: mirror everything into runtime.log, which the diagnostics bundle
+ * already collects — that makes a packaged crash recoverable after the fact
+ * from a user's exported diagnostics instead of lost.
+ */
+function recordMainProcessCrash(kind: string, detail: unknown): void {
+  const text =
+    detail instanceof Error
+      ? (detail.stack ?? `${detail.name}: ${detail.message}`)
+      : String(detail);
   // eslint-disable-next-line no-console
-  console.error("[uncaughtException]", err);
+  console.error(`[${kind}]`, detail);
+  // Never let crash recording itself throw inside a crash handler. The try is
+  // not redundant with the .catch: appendRuntimeLog closes over module-scope
+  // state declared much further down this file, so a crash raised during early
+  // module evaluation would hit its temporal dead zone synchronously.
+  try {
+    void appendRuntimeLog(`[${kind}] ${text}`).catch(() => undefined);
+  } catch {
+    // Logging unavailable this early — the console.error above still stands.
+  }
+}
+
+// EPIPE on stdio writes is a benign teardown race that Electron would
+// otherwise surface as a "holaOS encountered an error" modal. Trigger: a
+// child / utility process (or the embedded runtime) writes via
+// `console.info`/`.warn`/`.error` after its stdio pipe has been closed on the
+// parent side. Suppressed silently and deliberately; everything else is
+// recorded.
+process.on("uncaughtException", (err: NodeJS.ErrnoException) => {
+  if (err?.code === "EPIPE") return;
+  recordMainProcessCrash("uncaughtException", err);
 });
 process.on("unhandledRejection", (reason) => {
-  // eslint-disable-next-line no-console
-  console.error("[unhandledRejection]", reason);
+  recordMainProcessCrash("unhandledRejection", reason);
 });
 
 import { electronClient } from "@better-auth/electron/client";


### PR DESCRIPTION
## Summary

Registering an `uncaughtException` listener **suppresses Electron's own error dialog and its non-zero exit**, so these handlers are the entire crash story for the main process. What they did was `console.error` — which a packaged app has nowhere to show.

So every production crash in the 29k-line main process was invisible. The process kept running in a half-broken state (a failed IPC handler, a half-written DB, a runtime that never restarts) and the app just "stopped working" from the user's side.

## Nothing was catching the rest

The comments here described Sentry's `consoleLoggingIntegration` and *"the existing Sentry + Electron handlers"* as though a net existed behind them. It does not:

```
$ rg -i "sentry|crashReporter" apps/desktop --glob '!node_modules' -g '*.ts' -g '*.tsx' -g '*.json'
→ only stale comments; no @sentry/* dependency, crashReporter never started
```

The renderer registers no `window.onerror` or `unhandledrejection` either (`src/main.tsx` only wires `beforeunload`). Those comments are removed rather than left to reassure the next reader — that reassurance is exactly what stops someone adding real reporting.

## What changed

- Crashes now also go to **`runtime.log`**, which `diagnostics-bundle.ts` already collects (`archivePath: "runtime.log"`). A shipped crash becomes recoverable from a user's exported diagnostics instead of lost. **No new infrastructure and no new dependency.**
- Folds **two** separately-registered `uncaughtException` handlers into one — the first was a no-op EPIPE swallow, the second re-tested the same condition.
- EPIPE stays suppressed, deliberately, with its real rationale preserved: a child process writing to a half-closed stdio pipe during teardown, which Electron would otherwise surface as an error modal.

The `try` around the log call is not redundant with the `.catch`: `appendRuntimeLog` closes over module-scope state declared ~5,300 lines further down, so a crash raised during early module evaluation would hit its temporal dead zone *synchronously*. A crash handler must never be able to throw.

## Deliberately out of scope

**Crash semantics are unchanged.** Restoring fatal-exit behaviour, or adding a real crash reporter (`@sentry/electron` or `crashReporter.start()`), is a bigger decision than making the existing failure mode observable — it changes whether a half-broken app keeps running, which is a product call. This PR makes the problem visible so that decision can be made on evidence.

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 121/121
- [x] Both new guards **mutation-verified**: dropping the `runtime.log` write fails one; removing the EPIPE guard fails both.
- [ ] `npm run runtime:test` — not run; no runtime code touched.

One note on the tests: I wrote a third guard asserting the comments make no false claim about a reporter, then dropped it. It matched on the word "Sentry" — which the *new* comment legitimately uses to explain why the old claim was wrong. A word-filter guard that its own correct fix trips is not worth shipping.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)