### PR TITLE
perf(desktop): make AssistantTurn's memo actually hit

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
@@ -1,5 +1,9 @@
-  import { Fragment, type ReactNode } from "react";
+  import { Fragment, type ReactNode, useMemo } from "react";
 import { AssistantTurn } from "./AssistantTurn";
+import {
+  dedupePendingIntegrationsByIndex,
+  NO_PENDING_INTEGRATIONS,
+} from "./pendingIntegrationDedupe";
 import { UserTurn } from "./UserTurn";
 import type {
   AttachmentListItem,
@@ -14,6 +18,20 @@ import type {
 // arrived — so break the group and re-show the avatar + timestamp once the gap
 // from the previous message crosses this threshold.
 const ASSISTANT_GROUP_BREAK_MS = 60_000;
+
+/**
+ * Shared empty arrays for absent optional message fields.
+ *
+ * AssistantTurn is memoized on a comparator that compares these props by
+ * reference, so a fresh `[]` literal per render defeats the memo for every
+ * message that simply does not have that field.
+ */
+const NO_SEGMENTS: NonNullable<ChatMessage["segments"]> = [];
+const NO_EXECUTION_ITEMS: NonNullable<ChatMessage["executionItems"]> = [];
+const NO_OUTPUTS: NonNullable<ChatMessage["outputs"]> = [];
+const NO_PROPOSED_INTEGRATIONS: NonNullable<ChatMessage["proposedIntegrations"]> = [];
+const NO_MCP_AUTHORIZATIONS: NonNullable<ChatMessage["mcpAuthorizations"]> = [];
+const NO_PUBLISHED_POSTS: NonNullable<ChatMessage["publishedPosts"]> = [];
 
 export function ConversationTurns<Message extends ChatMessage>({
   messages,
@@ -99,16 +117,16 @@ export function ConversationTurns<Message extends ChatMessage>({
   // in the duplicate-Connect-card report. Only the latest assistant
   // turn that introduced a given `(provider, app_id)` should keep the
   // interactive card; earlier turns drop that entry.
-  const latestPendingIntegrationIndexByKey = new Map<string, number>();
-  for (let i = 0; i < messages.length; i += 1) {
-    const m = messages[i];
-    if (!m || m.role !== "assistant") continue;
-    for (const entry of m.pendingIntegrations ?? []) {
-      const key = `${entry.provider_id.trim().toLowerCase()}|${entry.app_id.trim().toLowerCase()}`;
-      if (!key) continue;
-      latestPendingIntegrationIndexByKey.set(key, i);
-    }
-  }
+  // Memoized on `messages` so the arrays handed to AssistantTurn keep their
+  // identity between renders. Previously this ran per render and each turn got
+  // a fresh `.filter()` result, so the comparator's
+  // `prev.pendingIntegrations === next.pendingIntegrations` was never true --
+  // AssistantTurn's memo never hit once, and every message in the
+  // conversation re-rendered on every ChatPane render.
+  const dedupedPendingIntegrationsByIndex = useMemo(
+    () => dedupePendingIntegrationsByIndex(messages),
+    [messages],
+  );
   const renderedTurns = messages.map((message, index) => {
     const wrapperClassName = getMessageWrapperClassName?.(message)?.trim();
     const previousMessage = messages[index - 1];
@@ -163,18 +181,15 @@ export function ConversationTurns<Message extends ChatMessage>({
           showExecutionInternals={showExecutionInternals}
           text={message.text}
           tone={message.tone ?? "default"}
-          segments={message.segments ?? []}
-          executionItems={message.executionItems ?? []}
-          outputs={message.outputs ?? []}
-          pendingIntegrations={(message.pendingIntegrations ?? []).filter(
-            (entry) => {
-              const key = `${entry.provider_id.trim().toLowerCase()}|${entry.app_id.trim().toLowerCase()}`;
-              return latestPendingIntegrationIndexByKey.get(key) === index;
-            },
-          )}
-          proposedIntegrations={message.proposedIntegrations ?? []}
-          mcpAuthorizations={message.mcpAuthorizations ?? []}
-          publishedPosts={message.publishedPosts ?? []}
+          segments={message.segments ?? NO_SEGMENTS}
+          executionItems={message.executionItems ?? NO_EXECUTION_ITEMS}
+          outputs={message.outputs ?? NO_OUTPUTS}
+          pendingIntegrations={
+            dedupedPendingIntegrationsByIndex[index] ?? NO_PENDING_INTEGRATIONS
+          }
+          proposedIntegrations={message.proposedIntegrations ?? NO_PROPOSED_INTEGRATIONS}
+          mcpAuthorizations={message.mcpAuthorizations ?? NO_MCP_AUTHORIZATIONS}
+          publishedPosts={message.publishedPosts ?? NO_PUBLISHED_POSTS}
           onAfterIntegrationBind={onAfterIntegrationBind}
           onAfterIntegrationProposalConnected={onAfterIntegrationProposalConnected}
           onAfterMcpAuthorized={onAfterMcpAuthorized}

--- a/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
@@ -32,6 +32,7 @@ const NO_OUTPUTS: NonNullable<ChatMessage["outputs"]> = [];
 const NO_PROPOSED_INTEGRATIONS: NonNullable<ChatMessage["proposedIntegrations"]> = [];
 const NO_MCP_AUTHORIZATIONS: NonNullable<ChatMessage["mcpAuthorizations"]> = [];
 const NO_PUBLISHED_POSTS: NonNullable<ChatMessage["publishedPosts"]> = [];
+const NO_BACKGROUND_TASK_REFERENCES: ChatBackgroundTaskReference[] = [];
 
 export function ConversationTurns<Message extends ChatMessage>({
   messages,
@@ -210,7 +211,9 @@ export function ConversationTurns<Message extends ChatMessage>({
               ? assistantFooterAccessory
               : null
           }
-          backgroundTaskReferences={message.backgroundTaskReferences ?? []}
+          backgroundTaskReferences={
+            message.backgroundTaskReferences ?? NO_BACKGROUND_TASK_REFERENCES
+          }
           onOpenBackgroundTaskReference={onOpenBackgroundTaskReference}
         />
       );

--- a/apps/desktop/src/components/panes/ChatPane/conversationTurnsMemo.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/conversationTurnsMemo.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, "ConversationTurns.tsx"), "utf-8");
+
+/**
+ * AssistantTurn is memoized on a comparator that compares its array/object
+ * props BY REFERENCE. A fresh `?? []` literal in the JSX therefore defeats the
+ * memo for every message lacking that field — which is every message, for the
+ * rarely-populated fields. One missed prop is enough to make the whole
+ * comparator useless, so this guards the invariant rather than any one prop.
+ */
+function assistantTurnJsx(): string {
+  const open = source.indexOf("<AssistantTurn");
+  assert.notEqual(open, -1, "ConversationTurns must still render <AssistantTurn>");
+  const close = source.indexOf("/>", open);
+  assert.notEqual(close, -1, "could not find the end of the <AssistantTurn> element");
+  return source.slice(open, close);
+}
+
+test("no AssistantTurn prop is defaulted to a freshly allocated literal", () => {
+  const jsx = assistantTurnJsx();
+  const inlineDefaults = [...jsx.matchAll(/(\w+)=\{[^}]*\?\?\s*(\[\]|\{\})/g)].map(
+    (match) => match[1],
+  );
+  assert.deepEqual(
+    inlineDefaults,
+    [],
+    `these props allocate a new value every render, so the memo can never hit: ${inlineDefaults.join(", ")}`,
+  );
+});
+
+test("backgroundTaskReferences uses the shared empty, like its siblings", () => {
+  assert.match(source, /const NO_BACKGROUND_TASK_REFERENCES/);
+  assert.match(
+    assistantTurnJsx(),
+    /backgroundTaskReferences=\{\s*message\.backgroundTaskReferences \?\? NO_BACKGROUND_TASK_REFERENCES\s*\}/,
+  );
+});

--- a/apps/desktop/src/components/panes/ChatPane/pendingIntegrationDedupe.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/pendingIntegrationDedupe.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ChatMessage } from "./types";
+import {
+  dedupePendingIntegrationsByIndex,
+  NO_PENDING_INTEGRATIONS,
+} from "./pendingIntegrationDedupe";
+
+function assistant(
+  id: string,
+  pendingIntegrations?: NonNullable<ChatMessage["pendingIntegrations"]>,
+): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    text: "",
+    createdAt: "2026-08-18T00:00:00.000Z",
+    ...(pendingIntegrations ? { pendingIntegrations } : {}),
+  } as ChatMessage;
+}
+
+function pending(providerId: string, appId: string) {
+  return { provider_id: providerId, app_id: appId } as NonNullable<
+    ChatMessage["pendingIntegrations"]
+  >[number];
+}
+
+test("only the newest turn introducing a (provider, app) keeps the card", () => {
+  const messages = [
+    assistant("a", [pending("notion", "app-1")]),
+    assistant("b", [pending("notion", "app-1")]),
+    assistant("c", [pending("slack", "app-2")]),
+  ];
+
+  const byIndex = dedupePendingIntegrationsByIndex(messages);
+
+  // The stale duplicate on the earlier turn is dropped — this is what stops
+  // the chat stacking up Connect / Pick-account cards the user already handled.
+  assert.deepEqual(byIndex[0], []);
+  assert.equal(byIndex[1]?.length, 1);
+  assert.equal(byIndex[2]?.length, 1);
+});
+
+test("provider/app matching is case- and whitespace-insensitive", () => {
+  const messages = [
+    assistant("a", [pending("  Notion ", "APP-1")]),
+    assistant("b", [pending("notion", "app-1")]),
+  ];
+
+  const byIndex = dedupePendingIntegrationsByIndex(messages);
+  assert.deepEqual(byIndex[0], []);
+  assert.equal(byIndex[1]?.length, 1);
+});
+
+// The rest of this file is the actual point: AssistantTurn's memo comparator
+// checks `prev.pendingIntegrations === next.pendingIntegrations`, so these
+// arrays must keep their identity across renders or the memo can never hit.
+
+test("messages with no pending integrations all share one empty array", () => {
+  const byIndex = dedupePendingIntegrationsByIndex([
+    assistant("a"),
+    assistant("b"),
+  ]);
+
+  assert.equal(byIndex[0], NO_PENDING_INTEGRATIONS);
+  assert.equal(byIndex[1], NO_PENDING_INTEGRATIONS);
+});
+
+test("a turn whose entries all survive reuses the message's own array", () => {
+  const entries = [pending("notion", "app-1")];
+  const messages = [assistant("a", entries)];
+
+  // Not merely deep-equal: the SAME reference. A defensive copy here would
+  // change identity every render and defeat the memo just as the old inline
+  // .filter() did.
+  assert.equal(dedupePendingIntegrationsByIndex(messages)[0], entries);
+});
+
+test("repeated calls on unchanged input return identical references", () => {
+  const messages = [
+    assistant("a", [pending("notion", "app-1")]),
+    assistant("b", [pending("notion", "app-1")]),
+    assistant("c"),
+  ];
+
+  const first = dedupePendingIntegrationsByIndex(messages);
+  const second = dedupePendingIntegrationsByIndex(messages);
+
+  // Index 1 and 2 are the memo-critical cases: unchanged input must yield
+  // reference-equal props. (Index 0 is a filtered copy, so it is legitimately
+  // a new array each call — but useMemo means it is only computed when
+  // `messages` actually changes.)
+  assert.equal(second[1], first[1]);
+  assert.equal(second[2], first[2]);
+});

--- a/apps/desktop/src/components/panes/ChatPane/pendingIntegrationDedupe.ts
+++ b/apps/desktop/src/components/panes/ChatPane/pendingIntegrationDedupe.ts
@@ -1,0 +1,58 @@
+import type { ChatMessage } from "./types";
+
+type PendingIntegrations = NonNullable<ChatMessage["pendingIntegrations"]>;
+
+/**
+ * Shared empty array for turns with no pending integrations.
+ *
+ * AssistantTurn is memoized on a comparator that compares this prop by
+ * reference, so handing it a fresh `[]` literal defeats the memo for every
+ * message that simply does not have the field — which is nearly all of them.
+ */
+export const NO_PENDING_INTEGRATIONS: PendingIntegrations = [];
+
+function integrationKey(entry: PendingIntegrations[number]): string {
+  return `${entry.provider_id.trim().toLowerCase()}|${entry.app_id.trim().toLowerCase()}`;
+}
+
+/**
+ * Per-message pending-integration cards, deduped so only the newest assistant
+ * turn that introduced a given `(provider, app_id)` keeps the interactive card.
+ *
+ * The agent re-emits the same proposal on every tool call, so without this the
+ * chat accumulates stacks of stale Connect / Pick-account cards from earlier
+ * turns even after the user has authorized.
+ *
+ * Returns one entry per message index. Callers must treat the result as
+ * immutable: identity is the point. Every returned array is either a shared
+ * empty, the message's own array, or a filtered copy — so for unchanged input
+ * the references are stable, which is what lets AssistantTurn's memo hit.
+ */
+export function dedupePendingIntegrationsByIndex(
+  messages: readonly ChatMessage[],
+): PendingIntegrations[] {
+  const latestIndexByKey = new Map<string, number>();
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (!message || message.role !== "assistant") continue;
+    for (const entry of message.pendingIntegrations ?? []) {
+      const key = integrationKey(entry);
+      if (!key) continue;
+      latestIndexByKey.set(key, i);
+    }
+  }
+
+  const byIndex: PendingIntegrations[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    const entries = messages[i]?.pendingIntegrations;
+    if (!entries?.length) {
+      byIndex[i] = NO_PENDING_INTEGRATIONS;
+      continue;
+    }
+    const kept = entries.filter((entry) => latestIndexByKey.get(integrationKey(entry)) === i);
+    // Nothing dropped → reuse the message's own array rather than the copy
+    // `.filter()` just made, so identity tracks the message itself.
+    byIndex[i] = kept.length === entries.length ? entries : kept;
+  }
+  return byIndex;
+}


### PR DESCRIPTION
## Summary

`AssistantTurn` is wrapped in `React.memo` with an explicit comparator that compares props by reference (`AssistantTurn/index.tsx:118`):

```js
prev.pendingIntegrations === next.pendingIntegrations &&
```

But `ConversationTurns.tsx:169` handed it:

```jsx
pendingIntegrations={(message.pendingIntegrations ?? []).filter((entry) => { … })}
```

`.filter()` returns a new array every time, so that clause was **unconditionally false**. The memo never hit — not sometimes, never. Every message in the conversation re-rendered on every `ChatPane` render.

## Why this one matters more than it looks

`ChatPane` re-renders on each keystroke, each stream frame, and each tick of the 1.2s workspace-skills poll. Every one of those dragged the entire transcript with it. This is the amplifier that makes typing lag and scroll jank scale with conversation length rather than staying flat — the other renderer costs multiply through it.

The remaining optional-array props had the same defect in milder form: `?? []` is a fresh reference every render, so any message lacking `segments` / `executionItems` / `outputs` / `proposedIntegrations` / `mcpAuthorizations` / `publishedPosts` also missed the memo. Those now use shared module-level constants.

## Behaviour is unchanged

Only the newest assistant turn introducing a given `(provider, app_id)` keeps its interactive card — the dedupe that stops the chat stacking stale Connect / Pick-account cards after the user has already authorized. The logic is identical; only *when it runs* and *what identity it returns* changed.

Three identity rules, all deliberate:
- No pending integrations → a **shared** empty array (the overwhelmingly common case).
- All entries survive → **the message's own array**, not the copy `.filter()` just made, so identity tracks the message itself.
- Some dropped → a filtered copy, recomputed only when `messages` actually changes.

## On the extraction

The dedupe moves into a pure `dedupePendingIntegrationsByIndex` rather than staying inline. That is deliberate: the fix *is* an identity guarantee, and identity is not something a source-snapshot test can demonstrate. Extracting it makes the actual property testable.

```
✔ only the newest turn introducing a (provider, app) keeps the card
✔ provider/app matching is case- and whitespace-insensitive
✔ messages with no pending integrations all share one empty array
✔ a turn whose entries all survive reuses the message's own array
✔ repeated calls on unchanged input return identical references
```

**Mutation-verified:** returning a fresh filtered copy (the old behaviour) fails 2 tests; using a fresh `[]` literal per message fails 2 tests.

## Caveat worth stating plainly

The new tests live under `src/`, and **no CI job currently runs `src/**/*.test.*`** — `test:electron` only covers `electron/*.test.mjs` and `scripts/*.test.mjs`. There are 64 test files in `src/` that never execute. So these pass locally (`node --import tsx --test`) but will not gate anything until that tier is wired up, which is a separate change.

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 119/119 (unchanged; no electron-tier tests touched)
- [x] New tests: 5/5 via `node --import tsx --test`, both identity guarantees mutation-verified
- [ ] `npm run runtime:test` — not run; no runtime code touched
- [ ] Not verified in the running app. The change is a referential-identity fix with unchanged logic, but if you want a render-count check before merging, say so and I'll do it.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)