### PR TITLE
ci(desktop): run the TypeScript test tiers, which nothing executed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,17 @@ jobs:
       # while that happens.
       - name: Desktop unit tests
         working-directory: apps/desktop
+        # This job sets ELECTRON_SKIP_BINARY_DOWNLOAD, so `require("electron")`
+        # throws "Electron failed to install correctly" for the handful of
+        # modules that import it at load time. In a plain node process the
+        # electron module resolves to a *path string* anyway (never the real
+        # API), so these tests already run with it undefined locally — the
+        # binary's absence is the only difference. Pointing the override at a
+        # path that need not exist makes resolution return that string instead
+        # of throwing, which matches local behaviour exactly and keeps the job
+        # from having to download Electron.
+        env:
+          ELECTRON_OVERRIDE_DIST_PATH: /nonexistent/electron-not-needed-for-unit-tests
         run: bun run test:unit
 
   runtime-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,21 @@ jobs:
         working-directory: apps/desktop
         run: bun run test:electron
 
+      # The TypeScript test tiers — electron/**/*.test.ts and src/**/*.test.{ts,tsx}
+      # — were likewise never run by anything. 30 files / 301 tests, covering
+      # real behaviour rather than source snapshots: PATH merging, the JSON
+      # state-file read/write guarantees, chat turn-card selection. They run
+      # under tsx and need no build.
+      #
+      # NOT included: src/**/*.test.mjs (64 files). That tier is the
+      # source-snapshot species and is currently 117/266 failing — it needs the
+      # same triage the electron/*.test.mjs files already got, which is a
+      # separate change. Gating the healthy tiers now stops the rot spreading
+      # while that happens.
+      - name: Desktop unit tests
+        working-directory: apps/desktop
+        run: bun run test:unit
+
   runtime-tests:
     if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest

--- a/apps/desktop/electron/shell-path.test.ts
+++ b/apps/desktop/electron/shell-path.test.ts
@@ -8,6 +8,10 @@ import {
 } from "./shell-path";
 
 const sep = path.delimiter;
+// Windows uses ";" regardless of the host we run these on. Joining Windows
+// paths with the host delimiter would split "C:\\Windows" at the drive letter,
+// which is why these cases used to pass only on Windows — i.e. never in CI.
+const winSep = ";";
 
 test("adds shell-only dirs while keeping shell ordering first", () => {
   const shellPath = ["/Users/x/.local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin"].join(sep);
@@ -40,7 +44,7 @@ test("ignores empty segments", () => {
 });
 
 test("appends existing Windows install dirs, current PATH first", () => {
-  const current = ["C:\\Windows\\system32", "C:\\Windows"].join(sep);
+  const current = ["C:\\Windows\\system32", "C:\\Windows"].join(winSep);
   const candidates = [
     "C:\\Users\\x\\.local\\bin", // exists (claude.exe)
     "C:\\Users\\x\\AppData\\Roaming\\npm", // exists (codex.cmd)
@@ -48,7 +52,12 @@ test("appends existing Windows install dirs, current PATH first", () => {
   ];
   const exists = (dir: string) => dir !== "C:\\Users\\x\\.bun\\bin";
 
-  const merged = computeWindowsSupplementalPath(current, candidates, exists).split(sep);
+  const merged = computeWindowsSupplementalPath(
+    current,
+    candidates,
+    exists,
+    winSep,
+  ).split(winSep);
 
   // Registry-inherited PATH still leads (system tools win).
   assert.deepEqual(merged.slice(0, 2), ["C:\\Windows\\system32", "C:\\Windows"]);
@@ -60,19 +69,25 @@ test("appends existing Windows install dirs, current PATH first", () => {
 });
 
 test("Windows supplemental is a no-op when no candidate dir exists", () => {
-  const current = ["C:\\Windows\\system32"].join(sep);
+  const current = ["C:\\Windows\\system32"].join(winSep);
   const merged = computeWindowsSupplementalPath(
     current,
     ["C:\\nope\\one", "C:\\nope\\two"],
     () => false,
+    winSep,
   );
   assert.equal(merged, current);
 });
 
 test("Windows supplemental doesn't duplicate an already-present dir", () => {
   const local = "C:\\Users\\x\\.local\\bin";
-  const current = ["C:\\Windows\\system32", local].join(sep);
-  const merged = computeWindowsSupplementalPath(current, [local], () => true).split(sep);
+  const current = ["C:\\Windows\\system32", local].join(winSep);
+  const merged = computeWindowsSupplementalPath(
+    current,
+    [local],
+    () => true,
+    winSep,
+  ).split(winSep);
 
   assert.equal(merged.filter((d) => d === local).length, 1);
 });

--- a/apps/desktop/electron/shell-path.ts
+++ b/apps/desktop/electron/shell-path.ts
@@ -89,8 +89,11 @@ function resolveLoginShellPath(): string | null {
 export function mergePathEntries(
   shellPath: string,
   currentPath: string,
+  // Injectable so the Windows branch stays testable off Windows. `;` vs `:`
+  // is the whole difference, and joining `C:\\Windows` with a `:` separator
+  // makes the drive letter indistinguishable from a separator.
+  sep: string = path.delimiter,
 ): string {
-  const sep = path.delimiter;
   const seen = new Set<string>();
   const merged: string[] = [];
   for (const dir of [...shellPath.split(sep), ...currentPath.split(sep)]) {
@@ -128,12 +131,15 @@ export function computeWindowsSupplementalPath(
   currentPath: string,
   candidateDirs: string[],
   existsFn: (dir: string) => boolean,
+  // Defaults to the host delimiter so production callers are unchanged; tests
+  // pass ";" so this Windows-only path can be exercised on any host.
+  sep: string = path.delimiter,
 ): string {
   const present = candidateDirs.filter((dir) => dir && existsFn(dir));
   if (present.length === 0) {
     return currentPath;
   }
-  return mergePathEntries(currentPath, present.join(path.delimiter));
+  return mergePathEntries(currentPath, present.join(sep), sep);
 }
 
 /**

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,7 +41,7 @@
     "build:renderer": "vite build",
     "build:electron": "tsup --config tsup.config.ts --minify",
     "e2e": "npm run rebuild:native && npm run build && node --test e2e/*.test.mjs",
-    "test:unit": "node --import tsx --test electron/**/*.test.ts src/**/*.test.ts",
+    "test:unit": "node --import tsx --test \"electron/**/*.test.ts\" \"src/**/*.test.ts\" \"src/**/*.test.tsx\"",
     "test:electron": "node --test electron/*.test.mjs scripts/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",

--- a/apps/desktop/src/components/panes/ChatPane/turnResultCards.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/turnResultCards.test.ts
@@ -59,7 +59,7 @@ test("collapses apps/<id>/* source files into one app card", () => {
   assert.deepEqual(cards, [{ kind: "app", appId: "github-tracker" }]);
 });
 
-test("shows multiple deliverables; path-less report counts, agents.md/skills don't", () => {
+test("shows multiple deliverables; path-less report counts, agents.md doesn't", () => {
   const outputs = [
     out({ id: "1", file_path: "outputs/a.docx" }),
     out({ id: "2", file_path: "outputs/b.xlsx" }),
@@ -71,7 +71,11 @@ test("shows multiple deliverables; path-less report counts, agents.md/skills don
   const { cards } = selectTurnResultCards(outputs);
   assert.deepEqual(
     cards.map((c) => (c.kind === "output" ? c.output.id : `app:${c.appId}`)),
-    ["1", "2", "3"],
+    // "5" is skills/foo/SKILL.md. isDeliverableManifest now treats an
+    // agent-built skill manifest as the artifact itself, deliberately mirroring
+    // outputDeliverableKind in lib/outputs so the inline chips and the Outputs
+    // library agree. AGENTS.md ("4") is still scaffolding and stays out.
+    ["1", "2", "3", "5"],
   );
 });
 
@@ -150,7 +154,7 @@ test("a video deliverable suppresses a same-turn markdown draft", () => {
   );
 });
 
-test("turnHasDisplayableOutputs: true for app/deliverable, false for managed-only", () => {
+test("turnHasDisplayableOutputs: true for app/deliverable/skill, false for scaffolding-only", () => {
   assert.equal(
     turnHasDisplayableOutputs([out({ id: "1", file_path: "apps/x/server.ts" })]),
     true,
@@ -159,11 +163,16 @@ test("turnHasDisplayableOutputs: true for app/deliverable, false for managed-onl
     turnHasDisplayableOutputs([out({ id: "1", file_path: "outputs/a.docx" })]),
     true,
   );
+  // A skill manifest is a deliverable in its own right, so it is asserted
+  // separately from the scaffolding set rather than lumped in with it.
+  assert.equal(
+    turnHasDisplayableOutputs([out({ id: "1", file_path: "skills/foo/SKILL.md" })]),
+    true,
+  );
   assert.equal(
     turnHasDisplayableOutputs([
       out({ id: "1", file_path: "AGENTS.md" }),
-      out({ id: "2", file_path: "skills/foo/SKILL.md" }),
-      out({ id: "3", file_path: "outputs/browser-screenshots/x.png" }),
+      out({ id: "2", file_path: "outputs/browser-screenshots/x.png" }),
     ]),
     false,
   );


### PR DESCRIPTION
## Summary

**94 of the desktop's 144 test files never ran.**

| Tier | Files | Tests | Gated before? |
|---|---:|---:|---|
| `electron/*.test.mjs` + `scripts/*.test.mjs` | 50 | 119 | yes |
| `electron/**/*.test.ts` | 8 | — | **no** |
| `src/**/*.test.{ts,tsx}` | 22 | — | **no** |
| `src/**/*.test.mjs` | 64 | 266 | **no** |

A `test:unit` script existed for the TypeScript tiers, but no job invoked it — and it would not have worked anyway, because its globs are unquoted. That is the **same defect as the api-server suite**: bun's shell expands `src/**/*.test.ts` itself and hands the result to node, shadowing node's own recursive expansion. It also never matched `.tsx`.

This PR fixes the script and runs it in CI: **30 files, 301 tests, all green.**

## Turning them on found two dead tests and two stale expectations

**`shell-path` — guaranteed-dead, not merely unrun.** The Windows PATH cases joined Windows paths with `path.delimiter`, which is `:` off Windows. So `["C:\\Windows\\system32", "C:\\Windows"].join(sep)` split back into `['C', '\\Windows\\system32', 'C', '\\Windows']` — the drive letter parsed as a separator. They could only ever pass on a Windows host, and CI has no Windows test runner.

`mergePathEntries` and `computeWindowsSupplementalPath` now take the delimiter as a **defaulted parameter**, so the Windows branch is exercised on any host. No production call site changes. This matters more than it looks: Windows PATH resolution is precisely the thing nobody can reproduce locally, so it needs to be testable on the machines people actually use.

**`turnResultCards` — a reversed decision.** Two tests asserted a `skills/**/SKILL.md` output is scaffolding. `isDeliverableManifest` deliberately reversed that — *"their manifest is the artifact"*, mirroring `outputDeliverableKind` in `lib/outputs` so the inline chips and the Outputs library agree. I verified this by probe (the skill path is flagged managed-noise *and* still emits a card) before concluding it was intent rather than a bug. Expectations updated; `AGENTS.md` is still scaffolding and still excluded.

## Deliberately not included

`src/**/*.test.mjs` — **64 files, currently 117 of 266 failing.** That tier is the source-snapshot species: tests that pin formatting and call shapes rather than behaviour, the same kind that were triaged out of `electron/*.test.mjs` earlier. Gating it would mean either a very large rewrite in this PR or turning CI red.

Gating the healthy tiers now stops the rot spreading while that triage happens on its own. I'd rather state the number than quietly leave it out of the table.

## Validation

- [x] `bun run test:unit` — 301/301, exit 0
- [x] `bun run test:electron` — 119/119, exit 0 (unchanged)
- [x] `npm run desktop:typecheck` — clean
- [x] Confirmed the command **exits cleanly without `--test-force-exit`** before wiring it in, so a leaked handle can't hang CI
- [ ] `npm run runtime:test` — not run; no runtime code touched

## Why this one matters for the others

Three test files I added in #484 and #485 land in these tiers, so until this merges they pass locally and gate nothing. This is the PR that makes the rest of the stack actually enforced.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)