### PR TITLE
fix(desktop): stop a boot-step failure from costing the user their window

### DIFF
--- a/apps/desktop/electron/boot-chain-guard.test.mjs
+++ b/apps/desktop/electron/boot-chain-guard.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+/**
+ * `app.whenReady()` runs ~2,600 lines: the state loads, all 249 IPC handler
+ * registrations, createMainWindow(), and finally app.on("activate"). A throw
+ * anywhere before the end takes out everything after it — including the window
+ * and, on macOS, the dock-click that would rebuild it.
+ *
+ * These guard the two things that keep an ordinary disk/DB failure from
+ * costing the user their window.
+ */
+
+test("the pre-window state loads cannot abort the ready chain", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  // Each of these can throw on a read-only/full userData dir or a corrupt or
+  // locked SQLite file, and none is needed to show a window.
+  for (const step of [
+    "loadBrowserPersistence",
+    "loadBrowserProfiles",
+    "loadFingerprintTemplates",
+    "bootstrapRuntimeDatabase",
+    "bootstrapControlPlaneDatabase",
+  ]) {
+    assert.match(
+      source,
+      new RegExp(`runBootStep\\(\\s*"[^"]+",\\s*${step},?\\s*\\)`),
+      `${step} is no longer wrapped in runBootStep`,
+    );
+  }
+
+  const helper = source.slice(source.indexOf("async function runBootStep"));
+  const body = helper.slice(0, helper.indexOf("\n}\n") + 3);
+  assert.match(body, /catch \(error\)/, "runBootStep no longer catches");
+  // Degrading silently would be its own bug: runtime.log is what the
+  // diagnostics bundle collects, so a degraded launch stays diagnosable.
+  assert.match(body, /appendRuntimeLog\(/, "boot failures are no longer recorded");
+});
+
+test("the ready chain has a terminal catch", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  const index = source.indexOf("app.whenReady().then(async () => {");
+  assert.notEqual(index, -1, "the main ready chain was not found");
+  const tail = source.slice(index);
+
+  // Registering process-level handlers suppresses Electron's own error dialog,
+  // so an unhandled rejection here is a dock icon that does nothing, silently.
+  assert.match(
+    tail,
+    /\}\)\s*\.catch\(\(error\) => \{/,
+    "app.whenReady() no longer has a terminal .catch",
+  );
+  assert.match(tail, /dialog\.showErrorBox\(/, "boot failure is no longer surfaced");
+});

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -26654,6 +26654,30 @@ app.on("web-contents-created", (_event, contents) => {
 // Independent ready step: the agent browser capability must come up regardless
 // of anything else in the long ready sequence below (it's what exposes browser_*
 // tools to agents), so an unrelated earlier failure can't leave it disabled.
+/**
+ * Run one boot step, keeping a failure from aborting the rest of
+ * `app.whenReady()`.
+ *
+ * Failures are recorded rather than swallowed: runtime.log is what the
+ * diagnostics bundle collects, so a degraded launch stays diagnosable after
+ * the fact instead of looking like a healthy one.
+ */
+async function runBootStep(
+  label: string,
+  run: () => Promise<unknown> | unknown,
+): Promise<void> {
+  try {
+    await run();
+  } catch (error) {
+    const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    // eslint-disable-next-line no-console
+    console.error(`[boot] ${label} failed`, error);
+    void appendRuntimeLog(`[boot] ${label} failed: ${detail}`).catch(
+      () => undefined,
+    );
+  }
+}
+
 app.whenReady().then(() => {
   void ensureDesktopBrowserServiceStarted();
 });
@@ -26677,11 +26701,21 @@ app.whenReady().then(async () => {
   installWindowsApplicationMenu();
   applyMainShellContentSecurityPolicy(session.defaultSession);
 
-  await loadBrowserPersistence();
-  await loadBrowserProfiles();
-  await loadFingerprintTemplates();
-  await bootstrapRuntimeDatabase();
-  bootstrapControlPlaneDatabase();
+  // Each of these loads persisted state from disk, and each can throw on
+  // ordinary field conditions: a read-only or full userData dir, a corrupt or
+  // locked SQLite file (bootstrapRuntimeDatabase is try/finally with no catch).
+  // None is a prerequisite for showing a window.
+  //
+  // Unguarded, any one of them aborted the remaining ~2,600 lines of this
+  // chain: all 249 IPC handler registrations, createMainWindow(), and the
+  // app.on("activate") registration at the very end -- so the user got a dock
+  // icon, no window, and clicking the dock did nothing. Degrading one
+  // subsystem is recoverable; losing the window is not.
+  await runBootStep("browser persistence", loadBrowserPersistence);
+  await runBootStep("browser profiles", loadBrowserProfiles);
+  await runBootStep("fingerprint templates", loadFingerprintTemplates);
+  await runBootStep("runtime database", bootstrapRuntimeDatabase);
+  await runBootStep("control-plane database", bootstrapControlPlaneDatabase);
   probeAuthCookieHealthOnce();
   setupDevRuntimeHotReload();
 
@@ -29327,7 +29361,28 @@ app.whenReady().then(async () => {
       createMainWindow();
     }
   });
-});
+})
+  .catch((error) => {
+    // Anything still escaping the chain is unexpected and leaves the app with
+    // no window and no explanation. Registering process-level handlers
+    // suppresses Electron's own error dialog, so without this the failure is
+    // completely silent: a dock icon that does nothing.
+    const detail =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    // eslint-disable-next-line no-console
+    console.error("[boot] app.whenReady failed", error);
+    void appendRuntimeLog(`[boot] app.whenReady failed: ${detail}`).catch(
+      () => undefined,
+    );
+    try {
+      dialog.showErrorBox(
+        "holaOS couldn't finish starting",
+        `${detail}\n\nThe log is in runtime.log; Help → Export diagnostics collects it.`,
+      );
+    } catch {
+      // A dialog this early can itself fail; the log above is the fallback.
+    }
+  });
 
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {


### PR DESCRIPTION
## Summary

`app.whenReady()` is a single ~2,600-line chain with **no `.catch()`** (`main.ts:26661`). It runs five state loads, then all **249** IPC handler registrations, then `createMainWindow()`, and registers `app.on("activate")` at the very end.

A throw anywhere in it took out everything after — no handlers, no window, and on macOS clicking the dock did nothing either, because the activate handler had never been registered.

And nothing was shown. Registering process-level handlers suppresses Electron's own error dialog, so the whole thing was silent: **a dock icon that does nothing.**

## These are not exotic failures

| Step | How it throws |
|---|---|
| `loadBrowserProfiles` | ends in `saveBrowserProfiles()` → a bare `writeFile`. A read-only or full userData dir is enough. |
| `bootstrapRuntimeDatabase` | `try { … } finally { database.close(); }` — **`finally`, no `catch`**. A corrupt DB, `SQLITE_CANTOPEN`, or WAL on a network/synced volume throws straight out. |
| `bootstrapControlPlaneDatabase` | same shape, and it opens a second legacy DB. |

None of them is a prerequisite for showing a window.

## The fix

Each state load now runs through `runBootStep`, which records the failure and continues. **Degrading one subsystem is recoverable; losing the window is not.**

Failures go to `runtime.log` — what the diagnostics bundle collects — so a degraded launch stays diagnosable instead of looking like a healthy one. Silently continuing would just trade one invisible failure for another.

The chain also gets a terminal `.catch` that logs and shows an error box, so anything still escaping is visible.

## Deliberately not in scope

**This does not reorder the chain.** Hoisting `createMainWindow()` and the runtime spawn ahead of ~2,600 lines of setup would also cut startup time noticeably — the window currently waits on work it doesn't need, and on Windows that includes a full runtime tarball extraction. But that's a behavioural change with its own risks, and it belongs in its own PR rather than riding along with a correctness fix.

Worth noting the codebase already solved exactly this problem once, for the browser service (`main.ts:26657`): *"so an unrelated earlier failure can't leave it disabled."* The window never got the same treatment.

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 121/121 (119 existing + 2 new)
- [x] All three guards **mutation-verified**: unwrapping any one boot step fails one; removing the terminal `.catch` fails one; making `runBootStep` stop recording failures fails one.
- [ ] `npm run runtime:test` — not run; no runtime code touched
- [ ] Not reproduced live. Forcing it means making userData read-only or corrupting the runtime DB; the throw paths are read directly from source and the guards are source-verified.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)