### PR TITLE
ci(runtime): make the search-tool tests hermetic instead of networked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,34 @@ jobs:
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile
 
+      # pi-search-tool / pi-find-tool call ensureTool("rg" | "fd", true), which
+      # falls back to querying the GitHub releases API and downloading the
+      # binary when the tool is not already present. In CI that turned an
+      # ordinary unit test into a network call against a rate-limited shared
+      # endpoint, and it failed intermittently with "The search backend (rg) is
+      # not available and could not be downloaded".
+      #
+      # getToolPath checks the system PATH before downloading, so installing
+      # these makes the tests deterministic without touching the runtime's
+      # download-on-demand behaviour, and without skipping the tests — which
+      # would just trade a flake for silent loss of coverage.
+      # pi already accepts Debian's `fdfind` as a system name for fd, so no
+      # symlink is needed here.
+      - name: Install search tools (rg, fd)
+        run: |
+          if ! command -v rg >/dev/null || ! (command -v fd >/dev/null || command -v fdfind >/dev/null); then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq ripgrep fd-find
+          fi
+          rg --version | head -1
+
       - name: Runtime state store + harness host
+        # PI_OFFLINE makes the download path unreachable rather than merely
+        # unused: if a tool is ever missing, the job fails immediately and
+        # identically instead of flaking on whether a network call happened to
+        # succeed. Combined with the install above, this step is hermetic.
+        env:
+          PI_OFFLINE: "1"
         run: bunx turbo run build test --filter=@holaboss/runtime-state-store --filter=@holaboss/runtime-harness-host
 
   sdk-app-sdk:


### PR DESCRIPTION
## Summary

`runtime-tests` fails intermittently with:

```
Error: The search backend (rg) is not available and could not be downloaded
```

It took out [#480](https://github.com/holaboss-ai/holaOS/pull/480) once, on a PR that touches nothing near `harness-host`.

`pi-search-tool` and `pi-find-tool` call `ensureTool("rg" | "fd", true)`. When the tool isn't already present, that queries the **GitHub releases API** and downloads a binary — so an ordinary unit test became a network call against a rate-limited shared endpoint, and it failed whenever that call didn't go through.

## The fix

`getToolPath` checks the system PATH *before* downloading:

```js
// Check system PATH - if found, just return the command name (it's in PATH)
```

So installing `rg` and `fd` on the runner removes the network dependency without touching the runtime's download-on-demand behaviour — which is deliberate and right for end users who don't have these tools.

**Not skipping the tests.** A `skip`-if-unavailable guard would convert a visible flake into silently losing 284 tests, which is the same failure mode I've been fixing elsewhere in this stack.

## Belt and braces: `PI_OFFLINE=1`

pi's tools-manager has an `isOfflineModeEnabled()` check. Setting `PI_OFFLINE=1` on the step makes the download path **unreachable rather than merely unused**: if the install step ever regresses, the job fails immediately and identically instead of flaking on whether a network call happened to succeed.

## Verified both directions locally

| | |
|---|---|
| system `rg`/`fd` present, `PI_OFFLINE=1` | harness-host **284/284** |
| `rg` hidden from PATH, `PI_OFFLINE=1` | fails in **0s**, no download attempted |

The second is the one that matters — it proves `PI_OFFLINE` actually gates the network call rather than the tests merely getting lucky.

## Small detail

No symlink for Debian's `fdfind`: pi already lists it in `systemBinaryNames` for `fd`. I wrote one first, then checked and removed it.

## Validation

- [x] Both directions verified locally (above)
- [x] The install step is a no-op when the runner image already ships the tools
- [ ] `npm run desktop:typecheck` / `npm run runtime:test` — CI-only change, no source touched

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)