### PR TITLE
fix(runtime): log durable-memory writeback failures instead of swallowing them

### DIFF
--- a/runtime/api-server/src/turn-memory-writeback.test.ts
+++ b/runtime/api-server/src/turn-memory-writeback.test.ts
@@ -19,6 +19,7 @@ import {
   refreshMemoryIndexes,
   waitForPendingWorkspaceMemoryTreeRebuilds,
   writeTurnDurableMemory,
+  writeTurnMemory,
   type TurnMemoryWritebackModelContext,
 } from "./turn-memory-writeback.js";
 import {
@@ -726,4 +727,45 @@ test("refreshMemoryIndexes can target specific interaction entities", async () =
   assert.equal(fs.existsSync(workflowSummaryPath), false);
 
   store.close();
+});
+
+test("writeTurnMemory logs a writeback failure instead of swallowing it", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hb-memory-writeback-log-"));
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+  try {
+    const turnResult = {
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      inputId: "input-1",
+    } as unknown as TurnResultRecord;
+
+    // No workspace seeded and a store that will reject the writeback, so the
+    // durable pass throws. The caller fires this without awaiting, so it must
+    // still resolve — but silently is what made a lost turn undiagnosable.
+    const returned = await writeTurnMemory({
+      store: {
+        ...store,
+        getTurnResult: () => null,
+      } as unknown as RuntimeStateStore,
+      turnResult,
+      modelContext: null,
+    });
+
+    assert.equal(returned, turnResult, "must resolve to the caller's turn result");
+    assert.equal(warnings.length, 1, "the failure must be logged exactly once");
+    assert.match(String(warnings[0]?.[0]), /\[memory\] durable writeback failed/);
+    assert.match(String(warnings[0]?.[0]), /input=input-1/);
+  } finally {
+    console.warn = originalWarn;
+    store.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/runtime/api-server/src/turn-memory-writeback.ts
+++ b/runtime/api-server/src/turn-memory-writeback.ts
@@ -588,7 +588,21 @@ export async function writeTurnMemory(params: {
       turnResult: params.turnResult,
       modelContext: params.modelContext ?? null,
     });
-  } catch {
+  } catch (error) {
+    // Never rethrow: the caller fires this without awaiting so it cannot block
+    // turn finalization, and a rejection there would surface as an unhandled
+    // rejection rather than anything useful.
+    //
+    // But it must not be silent either. This indexes the recall substrate --
+    // attachments, referenced images, output artifacts. A failure means the
+    // agent quietly cannot recall that turn's material later, with no error
+    // anywhere and nothing distinguishing it from a turn that had nothing to
+    // index. Log it so a "the agent forgot" report has something to look at.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[memory] durable writeback failed workspace=${params.turnResult.workspaceId} session=${params.turnResult.sessionId} input=${params.turnResult.inputId}`,
+      error,
+    );
     return (
       params.store.getTurnResult({
         workspaceId: params.turnResult.workspaceId,


### PR DESCRIPTION
## Summary

`writeTurnMemory` wrapped the entire durable-memory writeback in a bare `catch {}` and returned the previous turn result:

```ts
  } catch {
    return (
      params.store.getTurnResult({ … }) ?? params.turnResult
    );
  }
```

**Not rethrowing is correct.** The caller fires this without awaiting (`claimed-input-executor.ts:5335`) precisely so memory work can't block turn finalization or next-input pickup, and a rejection there would surface as an unhandled rejection rather than anything useful.

**Being silent is not.** This pass indexes the recall substrate — turn attachments, referenced images, output artifacts. A failure means the agent quietly cannot recall that turn's material later, with no error anywhere, and nothing to distinguish it from a turn that simply had nothing to index. "The agent forgot what I sent it" then has no evidence behind it at all.

Now logs workspace / session / input ids and keeps the existing return, so behaviour is otherwise unchanged.

## Scope note

This is only the *silence*. It does not change what gets indexed, when, or the fire-and-forget contract — all of which are deliberate. It makes an existing failure mode observable, which is a precondition for judging whether it happens often enough to warrant more.

Worth knowing for whoever picks that up: per-turn model *extraction* was retired on 2026-07-14 in favour of the agent-invoked `remember` tool (`turn-memory-writeback.ts:568`), so what remains here is artifact/document indexing only.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `turn-memory-writeback.test.ts` — 5/5 (4 existing + 1 new)
- [x] The new test asserts **both** halves: that it still resolves to the caller's turn result, and that the failure is logged exactly once with the input id
- [x] **Mutation-verified**: restoring the silent catch fails it
- [ ] Full `npm run runtime:test` — not run here; note the api-server suite only executes 13 of its 1106 tests until the glob fix lands (see #479's description)

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)