### PR TITLE
fix(channels): stop silently dropping replies to long-running turns

### DIFF
--- a/runtime/channel-gateway/src/egress-timeout.test.ts
+++ b/runtime/channel-gateway/src/egress-timeout.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type {
+  ChannelCapabilities,
+  ChannelConnector,
+  IncomingMessage,
+  IncomingMessageHandler,
+  OutgoingTarget,
+  SendResult,
+} from "./connector.js";
+import { ChannelEgress, defaultEgressTimeoutMs } from "./egress.js";
+import type {
+  ChannelRuntimePort,
+  FireMessageResult,
+  PollOutputsResult,
+} from "./ports.js";
+
+const PLAIN_CAPS: ChannelCapabilities = {
+  editMessages: false,
+  finalizeByResend: false,
+  reactions: false,
+  typing: false,
+  typingRefreshMs: 0,
+  markdown: "none",
+  maxMessageLength: 4096,
+  lengthUnit: "codepoints",
+  interactiveButtons: false,
+  threads: false,
+  media: { image: false, document: false, voice: false, video: false },
+};
+
+class PlainConnector implements ChannelConnector {
+  readonly platform = "wechat";
+  readonly connectionId = "default";
+  readonly key = "wechat:w1:default";
+  readonly capabilities = PLAIN_CAPS;
+  readonly workingText = "🤔 Working on it…";
+
+  sends: Array<{ text: string }> = [];
+  #handler: IncomingMessageHandler | null = null;
+  #counter = 0;
+
+  fingerprint(): string {
+    return "fp";
+  }
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  onMessage(handler: IncomingMessageHandler): void {
+    this.#handler = handler;
+  }
+  format(text: string): string {
+    return text;
+  }
+  async sendText(_target: OutgoingTarget, text: string): Promise<SendResult> {
+    this.#counter += 1;
+    this.sends.push({ text });
+    return { ok: true, messageId: String(this.#counter) };
+  }
+  async react(): Promise<void> {}
+  async unreact(): Promise<void> {}
+  async emit(message: IncomingMessage): Promise<void> {
+    await this.#handler?.(message);
+  }
+}
+
+/** A run that is still going — never reports a terminal event. */
+class NeverTerminalPort implements ChannelRuntimePort {
+  resolveWorkspaceId(): string {
+    return "w1";
+  }
+  fireMessage({ sessionId }: { sessionId: string }): FireMessageResult {
+    return { sessionId, inputId: "in-1", created: true };
+  }
+  getTurnArtifacts(): [] {
+    return [];
+  }
+  pollOutputs(): PollOutputsResult {
+    return { events: [], lastEventId: 0, terminal: null, finalText: null, error: null };
+  }
+}
+
+function makeMessage(): IncomingMessage {
+  return {
+    platform: "wechat",
+    connectionId: "default",
+    workspaceId: "w1",
+    chatId: "123",
+    chatType: "dm",
+    userId: "u1",
+    text: "hi",
+    messageId: "10",
+    updateId: 100,
+    attachments: [],
+  };
+}
+
+test("giving up on a reply tells the user instead of going quiet", async () => {
+  const connector = new PlainConnector();
+  const egress = new ChannelEgress({
+    port: new NeverTerminalPort(),
+    pollIntervalMs: 5,
+    timeoutMs: 40,
+  });
+
+  await egress.watch({
+    connector,
+    message: makeMessage(),
+    sessionId: "s1",
+    inputId: "in-1",
+  });
+
+  // Previously the loop just fell through with a log line, so the user was
+  // left on the "working" ack forever with no way to tell a slow run from a
+  // lost one.
+  const texts = connector.sends.map((s) => s.text);
+  assert.ok(texts.length >= 2, `expected a timeout notice, saw ${JSON.stringify(texts)}`);
+  assert.match(texts.at(-1) ?? "", /stopped waiting/i);
+});
+
+test("an aborted watch stays silent", async () => {
+  const connector = new PlainConnector();
+  const controller = new AbortController();
+  const egress = new ChannelEgress({
+    port: new NeverTerminalPort(),
+    pollIntervalMs: 5,
+    timeoutMs: 5_000,
+  });
+
+  const watching = egress.watch({
+    connector,
+    message: makeMessage(),
+    sessionId: "s1",
+    inputId: "in-1",
+    signal: controller.signal,
+  });
+  controller.abort();
+  await watching;
+
+  // Shutdown is not a timeout: the run is not abandoned, so telling the user
+  // it was would be wrong.
+  const texts = connector.sends.map((s) => s.text);
+  assert.ok(
+    !texts.some((t) => /stopped waiting/i.test(t)),
+    `abort must not deliver a timeout notice, saw ${JSON.stringify(texts)}`,
+  );
+});
+
+test("the default deadline outlasts the runner's own run ceiling", () => {
+  const original = process.env.SANDBOX_AGENT_RUN_TIMEOUT_S;
+  try {
+    // runner-worker.ts: DEFAULT_RUN_TIMEOUT_SECONDS = 1800. A shorter egress
+    // deadline abandons a healthy long turn while it is still running, and the
+    // reply is simply never delivered.
+    delete process.env.SANDBOX_AGENT_RUN_TIMEOUT_S;
+    assert.ok(
+      defaultEgressTimeoutMs() > 1800 * 1000,
+      `default ${defaultEgressTimeoutMs()}ms must exceed the 1800s run ceiling`,
+    );
+
+    // And it tracks the override rather than pinning a constant.
+    process.env.SANDBOX_AGENT_RUN_TIMEOUT_S = "3600";
+    assert.ok(defaultEgressTimeoutMs() > 3600 * 1000);
+
+    // The helper existing is not the point — ChannelEgress has to actually
+    // use it when no explicit timeout is supplied.
+    delete process.env.SANDBOX_AGENT_RUN_TIMEOUT_S;
+    const egress = new ChannelEgress({ port: new NeverTerminalPort() });
+    assert.equal(egress.timeoutMs, defaultEgressTimeoutMs());
+    assert.ok(egress.timeoutMs > 1800 * 1000);
+  } finally {
+    if (original === undefined) {
+      delete process.env.SANDBOX_AGENT_RUN_TIMEOUT_S;
+    } else {
+      process.env.SANDBOX_AGENT_RUN_TIMEOUT_S = original;
+    }
+  }
+});

--- a/runtime/channel-gateway/src/egress.ts
+++ b/runtime/channel-gateway/src/egress.ts
@@ -54,6 +54,28 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
  * This is the proven buffer-final path; live edit-in-place
  * streaming is a future enhancement gated on `capabilities.editMessages`.
  */
+/**
+ * How long to wait for a reply before giving up.
+ *
+ * This has to outlast the runner's own ceiling. It used to be a flat 10
+ * minutes while runner-worker.ts allows 30 (DEFAULT_RUN_TIMEOUT_SECONDS,
+ * overridable via SANDBOX_AGENT_RUN_TIMEOUT_S), so any turn taking 10-30
+ * minutes was abandoned here *while it was still running* -- the run completed
+ * normally and the reply was simply never delivered.
+ *
+ * Tracks the same env var, plus a margin for the terminal event to be polled
+ * after the run itself ends.
+ */
+const RUNNER_RUN_TIMEOUT_FALLBACK_SECONDS = 1800;
+const EGRESS_TIMEOUT_MARGIN_MS = 2 * 60 * 1000;
+
+export function defaultEgressTimeoutMs(): number {
+  const raw = Number(process.env.SANDBOX_AGENT_RUN_TIMEOUT_S);
+  const seconds =
+    Number.isFinite(raw) && raw > 0 ? raw : RUNNER_RUN_TIMEOUT_FALLBACK_SECONDS;
+  return seconds * 1000 + EGRESS_TIMEOUT_MARGIN_MS;
+}
+
 export class ChannelEgress {
   readonly #port: ChannelRuntimePort;
   readonly #logger?: LoggerLike;
@@ -64,7 +86,12 @@ export class ChannelEgress {
     this.#port = options.port;
     this.#logger = options.logger;
     this.#pollIntervalMs = options.pollIntervalMs ?? 1000;
-    this.#timeoutMs = options.timeoutMs ?? 10 * 60 * 1000;
+    this.#timeoutMs = options.timeoutMs ?? defaultEgressTimeoutMs();
+  }
+
+  /** Effective give-up deadline for a single reply, in ms. */
+  get timeoutMs(): number {
+    return this.#timeoutMs;
   }
 
   async watch(params: {
@@ -224,6 +251,15 @@ export class ChannelEgress {
         this.#logger?.warn?.(
           `channel egress: timed out waiting for reply session=${sessionId} input=${inputId}`,
         );
+        // Say so. Falling out of the loop silently left the user on the
+        // "received" ack forever, with no way to tell a slow run from a lost
+        // one -- and the run may well still be going.
+        await this.#deliver(
+          connector,
+          target,
+          "⚠️ Still working on this — I stopped waiting for the reply here, so it may arrive late or not at all. Send another message to retry.",
+        );
+        await this.#ack(connector, message, "failed");
       }
     } finally {
       typing?.stop();


### PR DESCRIPTION
## Summary

Two bugs on the same path, both ending with the user staring at the "working" ack forever.

### 1. The deadline was shorter than the runner's own ceiling

`egress.ts` waited a flat **10 minutes**; `runner-worker.ts` allows **30** (`DEFAULT_RUN_TIMEOUT_SECONDS = 1800`, overridable via `SANDBOX_AGENT_RUN_TIMEOUT_S`).

So any Slack / Telegram / WeChat / DingTalk turn taking 10–30 minutes was abandoned here **while the run was still going**. It completed normally on the runtime side and the reply was simply never delivered. Nothing failed; the answer just never arrived.

The deadline now tracks that env var, plus a margin for the terminal event to be polled after the run itself ends.

### 2. Giving up was silent

The loop fell through to a bare `logger.warn` — no `#deliver`, no ack:

```ts
if (!signal?.aborted) {
  this.#logger?.warn?.(`channel egress: timed out waiting for reply …`);
}
```

Nothing reached the user, so there was no way to tell a slow run from a lost one. It now says so and acks `failed`.

**An aborted watch stays silent.** Shutdown is not a timeout — telling the user their turn was abandoned when it wasn't would be its own bug. There's a test for that specifically.

## On the tests

Three tests, and the process is worth noting: **my deadline test initially failed to catch its own mutation.** Reverting to a flat 10 minutes still passed, because the test called `defaultEgressTimeoutMs()` directly instead of checking that `ChannelEgress` actually *uses* it. The class now exposes its effective `timeoutMs` and the test asserts through that. Both mutations are caught now:

| Mutation | Result |
|---|---|
| deadline back to a flat 10 min | fails the deadline test |
| timeout goes quiet again | fails the notice test |

## Not addressed here

`#deliver` logs and continues when `sendText` fails (`egress.ts:266`), so a send error still loses the reply. Same family, different fix — it needs a retry/escalation decision rather than a deadline change, so it doesn't belong in this PR.

## Validation

- [x] `bun run typecheck` (channel-gateway) — clean
- [x] `bun run test` (channel-gateway) — **79/79**
- [x] Both changes mutation-verified (above)
- [ ] Not exercised against a live Slack/WeChat connector. The behaviour is covered by the fake connector the existing egress tests already use, but the end-to-end path is unverified by me.

Worth knowing: `runtime-channel-gateway` has a `test` script but appears in **no CI filter**, so these 79 tests don't run in CI today. That's noted in #487 and is a separate change.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)