### PR TITLE
fix(runtime): bound the Composio client so a silent upstream can't wedge a turn

### DIFF
--- a/runtime/api-server/src/composio-api-client.test.ts
+++ b/runtime/api-server/src/composio-api-client.test.ts
@@ -260,3 +260,59 @@ test("createComposioApiClientFromEnv returns a configured client when both env v
   assert.ok(client);
   assert.equal(client?.honoBaseUrl, "https://hono.example");
 });
+
+test("a metadata read gives up instead of hanging on a silent upstream", async () => {
+  // An upstream that accepts the connection and then never answers. Node's
+  // fetch has no default timeout, so without a signal this await never
+  // settles — and it is the FIRST await of every claimed turn, via the
+  // integration proposal gate.
+  const neverResolves: typeof fetch = (_input, init) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(init.signal?.reason ?? new Error("aborted")),
+      );
+    });
+
+  const client = new ComposioApiClient({
+    honoBaseUrl: "https://example.test",
+    bearerToken: "token",
+    fetchImpl: neverResolves,
+    readTimeoutMs: 30,
+  });
+
+  const startedAt = Date.now();
+  await assert.rejects(() => client.listConnections({}));
+  assert.ok(
+    Date.now() - startedAt < 2_000,
+    "listConnections must abort on its own deadline, not hang",
+  );
+});
+
+test("tool execution gets a longer ceiling than a metadata read", async () => {
+  // A real remote action is legitimately slower than a listing, so the two
+  // must not share one deadline — but neither may be unbounded.
+  const signals: Array<AbortSignal | null | undefined> = [];
+  const capture: typeof fetch = async (_input, init) => {
+    signals.push(init?.signal);
+    return new Response(JSON.stringify({ ok: true, data: {} }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const client = new ComposioApiClient({
+    honoBaseUrl: "https://example.test",
+    bearerToken: "token",
+    fetchImpl: capture,
+  });
+
+  await client.listConnections({}).catch(() => undefined);
+  await client
+    .executeAction({ toolSlug: "GMAIL_SEND", connectedAccountId: "a", arguments: {} })
+    .catch(() => undefined);
+
+  assert.equal(signals.length, 2);
+  for (const signal of signals) {
+    assert.ok(signal, "every request must carry an abort signal");
+  }
+});

--- a/runtime/api-server/src/composio-api-client.ts
+++ b/runtime/api-server/src/composio-api-client.ts
@@ -34,7 +34,30 @@ export interface ComposioApiClientConfig {
   bearerToken: string;
   /** Override for tests. */
   fetchImpl?: typeof fetch;
+  /** Ceiling for metadata reads. Default {@link DEFAULT_READ_TIMEOUT_MS}. */
+  readTimeoutMs?: number;
+  /** Ceiling for tool execution / REST proxying. Default
+   *  {@link DEFAULT_EXECUTE_TIMEOUT_MS}. */
+  executeTimeoutMs?: number;
 }
+
+/**
+ * Metadata reads (connections, toolkit catalogue) sit on the turn's critical
+ * path: the integration proposal gate awaits listConnections as the FIRST
+ * await of every claimed turn, before the runner is spawned. Node's fetch has
+ * no default timeout, so an upstream that accepted the connection and then
+ * went quiet stalled the turn indefinitely -- no run_started, no error, and
+ * the queue worker's keepalive kept renewing the lease, so stale-claim
+ * recovery never fired either. Only a runtime restart cleared it.
+ */
+const DEFAULT_READ_TIMEOUT_MS = 15_000;
+
+/**
+ * Tool execution and REST proxying perform a real remote action, so they are
+ * legitimately slower than a metadata read -- but still bounded, because the
+ * alternative is the same indefinite stall one level down.
+ */
+const DEFAULT_EXECUTE_TIMEOUT_MS = 120_000;
 
 export interface ComposioApiClientErrorInfo {
   code: string;
@@ -127,6 +150,8 @@ export class ComposioApiClient {
   readonly honoBaseUrl: string;
   private readonly bearerToken: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly readTimeoutMs: number;
+  private readonly executeTimeoutMs: number;
 
   constructor(config: ComposioApiClientConfig) {
     if (!config.honoBaseUrl) {
@@ -138,6 +163,8 @@ export class ComposioApiClient {
     this.honoBaseUrl = config.honoBaseUrl.replace(/\/+$/, "");
     this.bearerToken = config.bearerToken;
     this.fetchImpl = config.fetchImpl ?? fetch;
+    this.readTimeoutMs = config.readTimeoutMs ?? DEFAULT_READ_TIMEOUT_MS;
+    this.executeTimeoutMs = config.executeTimeoutMs ?? DEFAULT_EXECUTE_TIMEOUT_MS;
   }
 
   /** Execute a Composio cataloged tool by slug on behalf of the session
@@ -276,6 +303,7 @@ export class ComposioApiClient {
         Accept: "application/json",
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.executeTimeoutMs),
     });
   }
 
@@ -286,6 +314,7 @@ export class ComposioApiClient {
         Authorization: `Bearer ${this.bearerToken}`,
         Accept: "application/json",
       },
+      signal: AbortSignal.timeout(this.readTimeoutMs),
     });
   }
 }

--- a/runtime/api-server/src/integration-connections-merged.ts
+++ b/runtime/api-server/src/integration-connections-merged.ts
@@ -45,7 +45,18 @@ async function remoteComposioRecords(): Promise<IntegrationConnectionRecord[]> {
     return conns
       .filter((c) => c.id.trim() && c.toolkitSlug.trim())
       .map(toRecord);
-  } catch {
+  } catch (error) {
+    // Degrading to "no remote connections" is deliberate — callers must still
+    // get the local set — but it is indistinguishable from the user genuinely
+    // having none. That matters most in the integration proposal gate, where
+    // it reads as "not connected" and requeues the user's message for 10
+    // minutes with the session flipped to WAITING_ON_USER. Log it so that
+    // outcome is at least traceable to an unreachable upstream.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[composio] listing remote connections failed; treating as none for this call",
+      error,
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Summary

`ComposioApiClient`'s `getJson` / `postJson` passed **no signal**, and Node's `fetch` has no default timeout. An upstream that accepted the connection and then went quiet stalled the caller indefinitely.

That lands on the worst possible path.

## Why this one is bad

`evaluatePendingIntegrationProposals` is the **first `await` of every claimed turn** (`claimed-input-executor.ts:3808`) — before the runner is spawned — and it fans out to `listConnections`.

So the user's message showed as queued and then **nothing**: no `run_claimed`, no `run_started`, no error, spinner forever. And it couldn't self-heal, because the queue worker's keepalive renews the lease independently — so stale-claim recovery never fired. Only a runtime restart cleared it.

## Two ceilings, not one

| Path | Timeout | Why |
|---|---|---|
| `listConnections`, `getConnection`, `listToolkitTools` | **15s** | metadata reads, on the turn's critical path |
| `executeAction`, `proxyRequest` | **120s** | a real remote action, legitimately slower |

A single blanket value would either strand turns behind a slow listing or cut genuine tool work short. Both are overridable via config.

## Also: the swallow downstream

`remoteComposioRecords` catches everything and returns `[]`. Degrading to "no remote connections" is deliberate — callers still need the local set — but it is **indistinguishable from the user genuinely having none**. In the proposal gate that reads as "not connected", which requeues the message with `availableAt = now + 10 min` and flips the session to `WAITING_ON_USER`.

That matters here specifically: adding a timeout without touching this would convert "hangs forever" into "silently requeued for ten minutes", which is not obviously an improvement. It now logs, so that outcome is at least traceable to an unreachable upstream.

## Deliberately not fixed here

**The fail-closed behaviour itself.** Distinguishing "upstream unreachable" from "no active connection" means changing what `listConnectionsMerged` returns, and it has **6 call sites** (`active-account-resolver`, `composio-schema-cache`, `integration-proposal-gate`, `runtime-agent-tools`, `workspace-integration-visibility`). That's a contract change deserving its own PR, not something to bolt onto a timeout fix.

There's also a real question there — blocking may be the *safe* choice when we can't verify a connection; the bug is that it's silent and mis-attributed to the user. That's a product call.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `composio-api-client.test.ts` — 12/12 (10 existing + 2 new)
- [x] The hang test uses a fetch that never resolves and asserts the call aborts on its own deadline — the actual failure mechanism, not a proxy
- [x] **Both timeouts mutation-verified**: removing either signal fails a test
- [ ] Not exercised against live Composio

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)