### PR TITLE
perf(runtime): keep backend run telemetry off the turn's critical path

### DIFF
--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -36,6 +36,21 @@ import {
 } from "./workspace-attachment-memory.js";
 import { retrieveWorkspaceMemory } from "./workspace-memory.js";
 
+/**
+ * Backend relay POSTs are queued rather than awaited by the turn (so a slow
+ * backend cannot stall the stdout drain), which means they land shortly AFTER
+ * processClaimedInput resolves. Assertions on delivery have to wait for that.
+ */
+async function waitForRelayCount(
+  relayed: readonly unknown[],
+  expected: number,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (relayed.length < expected && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 const tempDirs: string[] = [];
 const ORIGINAL_ENV = {
   SANDBOX_AGENT_RUNNER_COMMAND_TEMPLATE:
@@ -4936,6 +4951,7 @@ test("claimed input relays tool, output, and terminal run events for backend-own
     },
   });
 
+  await waitForRelayCount(relayedEvents, 4);
   assert.deepEqual(
     relayedEvents.map((event) => [event.sequence, event.eventType]),
     [
@@ -5128,6 +5144,7 @@ test("claimed input relays skill invocations, coalesced output, and waiting-user
     },
   });
 
+  await waitForRelayCount(relayedEvents, 7);
   assert.deepEqual(
     relayedEvents.map((event) => [event.sequence, event.eventType]),
     [
@@ -6351,5 +6368,98 @@ test("claimed input triggers durable-memory writeback after a completed turn", a
   );
   assert.equal(writebackCalls[0].inputId, queued.inputId);
   assert.equal(writebackCalls[0].assistantText, "Noted.");
+  store.close();
+});
+
+test("a slow backend does not sit on the turn's critical path", async () => {
+  const store = makeStore("hb-claimed-input-relay-nonblocking-");
+  const workspace = seedWorkspaceRecord(store, {
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  const queued = store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "hello" },
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+
+  const RELAY_DELAY_MS = 120;
+  const relayedSequences: number[] = [];
+  const slow = async () => {
+    await new Promise((resolve) => setTimeout(resolve, RELAY_DELAY_MS));
+  };
+
+  const startedAt = Date.now();
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    // run-start used to be awaited before the runner was even spawned
+    registerRunStartedFn: slow,
+    relayRunEventFn: async (params) => {
+      relayedSequences.push(params.sequence);
+      await slow();
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      for (let i = 0; i < 6; i += 1) {
+        await options.onEvent?.({
+          session_id: payload.session_id,
+          input_id: payload.input_id,
+          sequence: i + 1,
+          event_type: "tool_call",
+          payload: {
+            phase: "started",
+            tool_name: "read",
+            call_id: `call-${i}`,
+            tool_args: {},
+          },
+        });
+      }
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: 7,
+        event_type: "run_completed",
+        payload: { status: "completed" },
+      });
+      return { events: [], skippedLines: [], stderr: "", returnCode: 0, sawTerminal: true };
+    },
+  });
+  const elapsed = Date.now() - startedAt;
+
+  // The turn must not pay for the relays AT ALL. Serialized, run-start plus 6
+  // tool calls plus the terminal relays cost ~8 x RELAY_DELAY_MS before the
+  // turn can finish; queued, the turn is independent of RELAY_DELAY_MS.
+  // The bar sits just above real execution and far below the cost of even a
+  // couple of serialized relays, so partially reverting either half trips it.
+  const budget = 2 * RELAY_DELAY_MS;
+  assert.ok(
+    elapsed < budget,
+    `turn took ${elapsed}ms; it must not wait on relay POSTs (budget ${budget}ms, serialized cost ~${8 * RELAY_DELAY_MS}ms)`,
+  );
+
+  // Queued, not dropped: they land after the turn returns. Wait for the chain
+  // to drain before asserting delivery — that asynchrony is the point.
+  const deadline = Date.now() + 5_000;
+  while (relayedSequences.length < 7 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.ok(
+    relayedSequences.length >= 7,
+    `expected every relay to still be delivered, saw ${relayedSequences.length}`,
+  );
+
+  // Ordering still has to hold: sequences are assigned synchronously, so the
+  // backend sees them monotonically even though the POSTs are queued.
+  const sorted = [...relayedSequences].sort((a, b) => a - b);
+  assert.deepEqual(relayedSequences, sorted, "relayed sequences must stay ordered");
+
   store.close();
 });

--- a/runtime/api-server/src/claimed-input-executor.test.ts
+++ b/runtime/api-server/src/claimed-input-executor.test.ts
@@ -6463,3 +6463,94 @@ test("a slow backend does not sit on the turn's critical path", async () => {
 
   store.close();
 });
+
+test("a saturated relay queue still delivers the terminal run event", async () => {
+  const store = makeStore("hb-claimed-input-relay-terminal-");
+  const workspace = seedWorkspaceRecord(store, {
+    workspaceId: "workspace-1",
+    name: "Workspace 1",
+    harness: "pi",
+    status: "active",
+  });
+  store.enqueueInput({
+    workspaceId: workspace.id,
+    sessionId: "session-main",
+    payload: { text: "hello" },
+  });
+  const claimed = store.claimInputs({
+    limit: 1,
+    claimedBy: "sandbox-agent-ts-worker",
+    leaseSeconds: 300,
+  });
+
+  // The backend accepts nothing until released, so the serialized chain cannot
+  // drain and the queue saturates — the exact shape of a slow/unreachable
+  // backend during a long, chatty run.
+  let releaseBackend = () => {};
+  const backendGate = new Promise<void>((resolve) => {
+    releaseBackend = resolve;
+  });
+  const relayedEventTypes: string[] = [];
+  const TOOL_CALL_COUNT = 200;
+
+  await processClaimedInput({
+    store,
+    record: claimed[0],
+    claimedBy: "sandbox-agent-ts-worker",
+    registerRunStartedFn: async () => {
+      await backendGate;
+    },
+    relayRunEventFn: async (params) => {
+      await backendGate;
+      relayedEventTypes.push(params.eventType);
+    },
+    executeRunnerRequestFn: async (payload, options = {}) => {
+      for (let i = 0; i < TOOL_CALL_COUNT; i += 1) {
+        await options.onEvent?.({
+          session_id: payload.session_id,
+          input_id: payload.input_id,
+          sequence: i + 1,
+          event_type: "tool_call",
+          payload: {
+            phase: "started",
+            tool_name: "read",
+            call_id: `call-${i}`,
+            tool_args: {},
+          },
+        });
+      }
+      await options.onEvent?.({
+        session_id: payload.session_id,
+        input_id: payload.input_id,
+        sequence: TOOL_CALL_COUNT + 1,
+        event_type: "run_completed",
+        payload: { status: "completed" },
+      });
+      return { events: [], skippedLines: [], stderr: "", returnCode: 0, sawTerminal: true };
+    },
+  });
+
+  releaseBackend();
+  const deadline = Date.now() + 10_000;
+  while (
+    !relayedEventTypes.includes("run_completed") &&
+    Date.now() < deadline
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  // Shedding mid-stream telemetry is the point of the cap, so this run must
+  // genuinely have overflowed it — otherwise the assertion below proves nothing.
+  assert.ok(
+    relayedEventTypes.length < TOOL_CALL_COUNT,
+    `expected the queue to overflow, but all ${relayedEventTypes.length} events were kept`,
+  );
+  // The terminal is what the backend's agent_runs row depends on. Dropping it
+  // leaves that row reading "running" forever with nothing to correct it.
+  assert.ok(
+    relayedEventTypes.includes("run_completed"),
+    `terminal run event was dropped; relayed ${relayedEventTypes.length} events: ${[...new Set(relayedEventTypes)].join(", ")}`,
+  );
+
+  store.close();
+});

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -101,6 +101,15 @@ const PI_SESSION_MANAGER_MODULE_PATH = path.join(
   "session-manager.js",
 );
 const PI_SESSION_DIR_RELATIVE = path.join(".holaboss", "pi-sessions");
+/**
+ * Ceiling on relay POSTs queued but not yet sent. Each has its own 2s abort
+ * budget and they are serialized to preserve ordering, so an unreachable
+ * backend would otherwise let a long, chatty run accumulate an unbounded
+ * queue. Dropping is correct here: this is telemetry, and the run's own
+ * event log in the store is the source of truth.
+ */
+const BACKEND_RELAY_MAX_PENDING = 64;
+
 const PROVIDER_TERMINATION_RECOVERY_MIN_INPUT_TOKENS = 250_000;
 const PROVIDER_TERMINATION_RECOVERY_MIN_MODEL_TURNS = 24;
 const PROVIDER_TERMINATION_RECOVERY_MIN_TOOL_CALLS = 12;
@@ -4140,14 +4149,40 @@ export async function processClaimedInput(params: {
       params.registerRunStartedFn ?? registerWorkspaceAgentRunStarted;
     const relayRunEvent =
       params.relayRunEventFn ?? registerWorkspaceAgentRunEvent;
-    await registerRunStarted({
+    // Backend run telemetry is best-effort (postWorkspaceAgentRunRequest logs
+    // and returns; it never throws) and nothing here consumes its result -- but
+    // it was awaited, so every turn for a signed-in user paid up to its full 2s
+    // abort budget before the runner was even spawned.
+    //
+    // It becomes the head of a chain instead. Later relays queue behind it, so
+    // the backend still sees run-start before any event, while the turn stops
+    // waiting on it.
+    let backendRelayPending = 0;
+    let backendRelayDropped = 0;
+    let backendRelayChain: Promise<void> = registerRunStarted({
       workspaceId: record.workspaceId,
       sessionId: record.sessionId,
       inputId: record.inputId,
       runId,
       selectedModel,
       runtimeBinding,
-      });
+    }).catch(() => undefined);
+
+    /** Queue a relay POST behind the ones already in flight, without waiting. */
+    const enqueueBackendRelay = (send: () => Promise<void>): void => {
+      if (backendRelayPending >= BACKEND_RELAY_MAX_PENDING) {
+        // A dead backend must not grow an unbounded queue in a long run.
+        backendRelayDropped += 1;
+        return;
+      }
+      backendRelayPending += 1;
+      backendRelayChain = backendRelayChain
+        .then(send)
+        .catch(() => undefined)
+        .finally(() => {
+          backendRelayPending -= 1;
+        });
+    };
 
     const baseHarnessTimeoutSeconds =
       resolveRuntimeHarnessPlugin(harness)?.timeoutSeconds({
@@ -4269,17 +4304,25 @@ export async function processClaimedInput(params: {
         1,
       );
       lastRelayedRunEventSequence = relaySequence;
-      await relayRunEvent({
-        workspaceId: record.workspaceId,
-        sessionId: record.sessionId,
-        inputId: record.inputId,
-        runId,
-        sequence: relaySequence,
-        eventType: relayParams.eventType,
-        payload: relayParams.payload,
-        timestamp: relayParams.timestamp,
-        runtimeBinding,
-          });
+      // The sequence above is assigned synchronously, so relay ordering is
+      // fixed here even though the POST itself is queued rather than awaited.
+      // This function used to await the request while sitting inside the
+      // stdout drain loop, which meant nothing else was read from the harness
+      // -- and so nothing reached the store the desktop tails -- for up to 2s
+      // per tool call and per 1200 characters of output. That is the stutter.
+      enqueueBackendRelay(() =>
+        relayRunEvent({
+          workspaceId: record.workspaceId,
+          sessionId: record.sessionId,
+          inputId: record.inputId,
+          runId,
+          sequence: relaySequence,
+          eventType: relayParams.eventType,
+          payload: relayParams.payload,
+          timestamp: relayParams.timestamp,
+          runtimeBinding,
+        }),
+      );
     };
 
     const flushPendingOutputDelta = async (): Promise<void> => {
@@ -5379,6 +5422,17 @@ export async function processClaimedInput(params: {
           preferredSequence:
             Math.max(terminalEventToRelay.sequence, 1) + (runStatePayload ? 1 : 0),
         });
+      }
+      // Deliberately NOT awaited. The queued relays keep draining on their own
+      // in this long-lived process, and the store already holds the
+      // authoritative event log -- awaiting here would just move the cost from
+      // mid-stream to end-of-turn, delaying finalization and next-input pickup
+      // for a telemetry POST nobody is waiting on.
+      void backendRelayChain;
+      if (backendRelayDropped > 0) {
+        console.warn(
+          `[relay] dropped ${backendRelayDropped} backend run events for run ${runId} (queue over ${BACKEND_RELAY_MAX_PENDING})`,
+        );
       }
       maybeCreateMainSessionCompletionNotification({
         store,

--- a/runtime/api-server/src/claimed-input-executor.ts
+++ b/runtime/api-server/src/claimed-input-executor.ts
@@ -109,6 +109,14 @@ const PI_SESSION_DIR_RELATIVE = path.join(".holaboss", "pi-sessions");
  * event log in the store is the source of truth.
  */
 const BACKEND_RELAY_MAX_PENDING = 64;
+/**
+ * Relay frames that are never dropped, however saturated the queue is. These
+ * carry the run's state; everything else is per-step telemetry that a reader
+ * can do without. Losing a terminal frame leaves the backend's `agent_runs` row
+ * reading "running" with no later correction.
+ */
+const BACKEND_RELAY_REQUIRED_EVENT_TYPES: ReadonlySet<BackendAgentRunEventType> =
+  new Set(["run_state", "run_completed", "run_failed"]);
 
 const PROVIDER_TERMINATION_RECOVERY_MIN_INPUT_TOKENS = 250_000;
 const PROVIDER_TERMINATION_RECOVERY_MIN_MODEL_TURNS = 24;
@@ -4168,9 +4176,21 @@ export async function processClaimedInput(params: {
       runtimeBinding,
     }).catch(() => undefined);
 
-    /** Queue a relay POST behind the ones already in flight, without waiting. */
-    const enqueueBackendRelay = (send: () => Promise<void>): void => {
-      if (backendRelayPending >= BACKEND_RELAY_MAX_PENDING) {
+    /**
+     * Queue a relay POST behind the ones already in flight, without waiting.
+     *
+     * `required` marks the frames that carry the run's state rather than its
+     * telemetry -- run_state and the run_completed / run_failed terminal. Those
+     * bypass the cap: dropping mid-stream output costs the backend some detail,
+     * but dropping the terminal leaves its agent_runs row reading "running"
+     * forever, and nothing later corrects it. Shedding load is only safe on the
+     * frames a reader can do without.
+     */
+    const enqueueBackendRelay = (
+      send: () => Promise<void>,
+      options: { required?: boolean } = {},
+    ): void => {
+      if (!options.required && backendRelayPending >= BACKEND_RELAY_MAX_PENDING) {
         // A dead backend must not grow an unbounded queue in a long run.
         backendRelayDropped += 1;
         return;
@@ -4310,18 +4330,20 @@ export async function processClaimedInput(params: {
       // stdout drain loop, which meant nothing else was read from the harness
       // -- and so nothing reached the store the desktop tails -- for up to 2s
       // per tool call and per 1200 characters of output. That is the stutter.
-      enqueueBackendRelay(() =>
-        relayRunEvent({
-          workspaceId: record.workspaceId,
-          sessionId: record.sessionId,
-          inputId: record.inputId,
-          runId,
-          sequence: relaySequence,
-          eventType: relayParams.eventType,
-          payload: relayParams.payload,
-          timestamp: relayParams.timestamp,
-          runtimeBinding,
-        }),
+      enqueueBackendRelay(
+        () =>
+          relayRunEvent({
+            workspaceId: record.workspaceId,
+            sessionId: record.sessionId,
+            inputId: record.inputId,
+            runId,
+            sequence: relaySequence,
+            eventType: relayParams.eventType,
+            payload: relayParams.payload,
+            timestamp: relayParams.timestamp,
+            runtimeBinding,
+          }),
+        { required: BACKEND_RELAY_REQUIRED_EVENT_TYPES.has(relayParams.eventType) },
       );
     };
 


### PR DESCRIPTION
## Summary

Two awaits on backend relay POSTs — each with its own 2s abort budget — sat directly on the path a user is waiting on. Both are best-effort: `postWorkspaceAgentRunRequest` logs and returns, **never throws**, and nothing consumes a result.

**1. `registerRunStarted` was awaited before the runner was spawned** (`claimed-input-executor.ts:4143`). Every turn for a signed-in user paid up to 2s of pure latency before the model was contacted.

**2. `relayBackendRunEvent` was awaited *inside the stdout drain loop*** (`:4732`, `:4741`). While it was in flight, nothing else was read from the harness — so nothing was written to the store the desktop tails. Up to 2s per tool call, and per 1200 characters of output.

That second one is the stuttering-text symptom: the turn was progressing fine, the UI just wasn't being fed.

## Approach

Run-start now heads a promise chain; relays queue behind it. The relay **sequence is still assigned synchronously**, so the backend sees events in order and after run-start — only the *waiting* is removed. The queue is capped (`BACKEND_RELAY_MAX_PENDING = 64`) so an unreachable backend can't grow it without bound in a long run, and drops are logged.

## What the test caught, before review had to

My first version awaited the chain at end-of-turn, to be safe. The new test failed it: **980ms against a 960ms floor.** That await just moved the cost from mid-stream to turn finalization, delaying next-input pickup for a POST nobody is waiting on. The store holds the authoritative event log either way, so the chain now drains on its own in this long-lived process.

I also had to tighten the test's own threshold: my first bar (8 × delay) was loose enough that a *partial* revert still passed. It now asserts the turn doesn't pay for relays **at all**, and both halves fail independently:

| Mutation | Result |
|---|---|
| re-await the relay inline | fails — `turn took 871ms; budget 240ms` |
| re-await run-start | fails |

## Contract change — please look here

Relays now land **shortly after** `processClaimedInput` resolves rather than before it. Two existing tests asserted delivery synchronously. Their assertions are unchanged; they just wait for the boundary I introduced.

I checked that this is the only behavioural consequence rather than assuming it: **diffed the failing-test set against clean `main`** and confirmed no other test regresses.

```
clean main   49 pass /  7 fail
this branch  50 pass /  7 fail     (+1 = the new test; same 7 failures)
```

Those 7 are pre-existing and fixed separately in #480.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `claimed-input-executor.test.ts` — 50/57, with the failing set **identical to clean main**
- [x] New test mutation-verified in both directions
- [ ] Not measured against a live backend — the win is structural (removing awaits), and the test drives it with an injected slow relay rather than a real one

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)