### PR TITLE
fix(harness): give the Claude Code harness the watchdogs codex already has

### DIFF
--- a/runtime/harness-host/src/claude-code-watchdog.test.ts
+++ b/runtime/harness-host/src/claude-code-watchdog.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import { decodeHarnessHostClaudeCodeRequestBase64 } from "./contracts.js";
+import { runClaudeStreamHarness } from "./claude-code.js";
+
+const tempDirs: string[] = [];
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  process.env = { ...originalEnv };
+});
+
+function tempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** A stand-in CLI that starts fine and then produces nothing at all. */
+function wedgedBinary(dir: string): string {
+  const file = path.join(dir, "wedged.mjs");
+  fs.writeFileSync(file, "setInterval(() => {}, 1000);\n", "utf8");
+  const shim = path.join(dir, "wedged.sh");
+  fs.writeFileSync(shim, `#!/bin/sh\nexec "${process.execPath}" "${file}"\n`, "utf8");
+  fs.chmodSync(shim, 0o755);
+  return shim;
+}
+
+function makeRequest(cwd: string) {
+  return decodeHarnessHostClaudeCodeRequestBase64(
+    Buffer.from(
+      JSON.stringify({
+        workspace_id: "workspace-1",
+        session_id: "session-1",
+        input_id: "input-1",
+        instruction: "hello",
+        agent_cwd: cwd,
+        workspace_dir: cwd,
+        model_client: {
+          model_proxy_provider: "openai_compatible",
+          api_key: "test-key",
+          base_url: "http://127.0.0.1:1/v1",
+        },
+        workspace_config_checksum: "x",
+        timeout_seconds: 600,
+        model_id: "x",
+        provider_id: "x",
+        context: {},
+      }),
+    ).toString("base64"),
+  );
+}
+
+test("a CLI that never emits anything fails fast instead of spinning", async () => {
+  const dir = tempDir("hb-claude-watchdog-");
+  process.env.HOLABOSS_CLAUDE_PATH = wedgedBinary(dir);
+
+  const emitted: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  // Capture only our own event lines and pass everything else straight
+  // through — node:test writes its own protocol frames to this same stream.
+  (process.stdout as unknown as { write: unknown }).write = ((
+    chunk: unknown,
+    ...rest: unknown[]
+  ) => {
+    const text = typeof chunk === "string" ? chunk : "";
+    if (text.startsWith('{"session_id"')) {
+      emitted.push(text);
+      return true;
+    }
+    return (originalWrite as (...args: unknown[]) => boolean)(chunk, ...rest);
+  }) as typeof process.stdout.write;
+
+  const startedAt = Date.now();
+  try {
+    await runClaudeStreamHarness(makeRequest(dir), {
+      id: "claude-code",
+      label: "claude",
+      defaultBinary: "claude",
+      binaryEnv: "HOLABOSS_CLAUDE_PATH",
+      modelEnv: "HOLABOSS_CLAUDE_MODEL",
+      argsEnv: "HOLABOSS_CLAUDE_ARGS",
+      // Without a watchdog here this hangs until the api-server's 900s idle
+      // cap, which is the whole bug: a 15-minute spinner and then a generic
+      // "runner command became idle".
+      firstFrameTimeoutMs: 150,
+    });
+  } finally {
+    (process.stdout as unknown as { write: unknown }).write = originalWrite;
+  }
+  const elapsed = Date.now() - startedAt;
+
+  assert.ok(elapsed < 10_000, `harness should give up promptly, took ${elapsed}ms`);
+
+  const events = emitted
+    .join("")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as { event_type?: string; payload?: Record<string, unknown> };
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is { event_type?: string; payload?: Record<string, unknown> } => Boolean(e));
+
+  const failed = events.find((e) => e.event_type === "run_failed");
+  assert.ok(failed, `expected a run_failed event, saw ${events.map((e) => e.event_type).join(",")}`);
+  // The message has to name the actual condition — "became idle" 15 minutes
+  // later is what made this undiagnosable.
+  assert.match(String(failed.payload?.error ?? ""), /first turn|emitted nothing/i);
+});

--- a/runtime/harness-host/src/claude-code.ts
+++ b/runtime/harness-host/src/claude-code.ts
@@ -71,6 +71,9 @@ export interface ClaudeStreamHarnessOptions {
   modelEnv: string;
   /** Env var for shell-split default args, e.g. "HOLABOSS_CLAUDE_ARGS". */
   argsEnv: string;
+  /** Watchdog overrides (tests). Defaults below. */
+  firstFrameTimeoutMs?: number;
+  inactivityTimeoutMs?: number;
 }
 
 const CLAUDE_STREAM_OPTIONS: ClaudeStreamHarnessOptions = {
@@ -223,6 +226,83 @@ export async function runClaudeStreamHarness(
   let sessionId: string | null = null;
   let finalStatus: "completed" | "failed" = "completed";
   let finalError: string | null = null;
+
+  // Watchdogs. Ported from the codex harness, which has had both since it was
+  // written; this harness had neither, so a wedged `claude` CLI (an auth
+  // prompt, a stalled network read, an unanswered control frame) produced a
+  // spinner until the api-server's 900s idle cap, then a generic "runner
+  // command became idle" with nothing to diagnose from.
+  //
+  // ts-runner's fast 60s first-event watchdog does not cover this: we emit
+  // run_started as soon as the process spawns, which clears it before the CLI
+  // has produced anything. Emitting it late would delay the UI's "working"
+  // state for every healthy run, so the timers live here instead.
+  const FIRST_FRAME_TIMEOUT_MS = opts.firstFrameTimeoutMs ?? 30_000;
+  const INACTIVITY_TIMEOUT_MS = opts.inactivityTimeoutMs ?? 10 * 60 * 1000;
+  let watchdogFired = false;
+  let firstFrameSeen = false;
+  let firstFrameTimer: NodeJS.Timeout | null = null;
+  let inactivityTimer: NodeJS.Timeout | null = null;
+
+  const fireWatchdog = (reason: string): void => {
+    if (watchdogFired) return;
+    watchdogFired = true;
+    finalStatus = "failed";
+    finalError = reason;
+    if (firstFrameTimer) {
+      clearTimeout(firstFrameTimer);
+      firstFrameTimer = null;
+    }
+    if (inactivityTimer) {
+      clearTimeout(inactivityTimer);
+      inactivityTimer = null;
+    }
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // already dead
+    }
+    // A CLI that ignores SIGTERM must not hold the host process open.
+    setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already dead
+      }
+    }, 5_000).unref();
+  };
+
+  const resetInactivityTimer = (): void => {
+    if (inactivityTimer) {
+      clearTimeout(inactivityTimer);
+    }
+    inactivityTimer = setTimeout(() => {
+      fireWatchdog(
+        `${opts.label} produced no output for ${Math.round(INACTIVITY_TIMEOUT_MS / 60_000)} minutes`,
+      );
+    }, INACTIVITY_TIMEOUT_MS);
+    inactivityTimer.unref();
+  };
+
+  /** A parsed CLI frame is real progress — heartbeats alone would not be. */
+  const markActivity = (): void => {
+    if (!firstFrameSeen) {
+      firstFrameSeen = true;
+      if (firstFrameTimer) {
+        clearTimeout(firstFrameTimer);
+        firstFrameTimer = null;
+      }
+    }
+    resetInactivityTimer();
+  };
+
+  firstFrameTimer = setTimeout(() => {
+    if (firstFrameSeen) return;
+    fireWatchdog(
+      `${opts.label} emitted nothing in the first ${FIRST_FRAME_TIMEOUT_MS / 1000}s — likely stuck before its first turn`,
+    );
+  }, FIRST_FRAME_TIMEOUT_MS);
+  firstFrameTimer.unref();
   let outputText = "";
   // True once any partial stream_event delta (text/thinking) has been emitted.
   // With --include-partial-messages Claude streams token-level deltas AND then
@@ -255,6 +335,7 @@ export async function runClaudeStreamHarness(
     } catch {
       return;
     }
+    markActivity();
     handleClaudeMessage(msg);
   });
 
@@ -446,6 +527,14 @@ export async function runClaudeStreamHarness(
   const exitCode = await new Promise<number>((resolve) => {
     child.on("close", (code) => resolve(code ?? 0));
   });
+  if (firstFrameTimer) {
+    clearTimeout(firstFrameTimer);
+    firstFrameTimer = null;
+  }
+  if (inactivityTimer) {
+    clearTimeout(inactivityTimer);
+    inactivityTimer = null;
+  }
 
   // Wipe the temp --mcp-config file as soon as claude has exited.
   // The file contains decrypted MCP env (Notion OAuth tokens, etc.),


### PR DESCRIPTION
## Summary

`runClaudeStreamHarness` waited on the child with a bare close listener and **no timers at all**:

```ts
const exitCode = await new Promise<number>((resolve) => {
  child.on("close", (code) => resolve(code ?? 0));
});
```

So a wedged `claude` CLI — an auth prompt, a stalled network read, an unanswered control frame — produced a spinner until the api-server's **900s** idle cap, and then a generic *"runner command became idle"* with nothing in it to diagnose from.

## Why the existing watchdog didn't cover it

ts-runner has a fast 60s first-event timer (`HARNESS_HOST_FIRST_EVENT_TIMEOUT_MS`). But this harness emits `run_started` **as soon as the process spawns** (`claude-code.ts:156`), which clears that timer before the CLI has produced anything.

Emitting `run_started` late would fix the watchdog at the cost of delaying the UI's "working" state on *every healthy run* — the wrong trade. So the timers belong in the harness.

## Ported, not invented

`codex.ts` has had both since it was written. This is the same pair:

| Watchdog | Trigger |
|---|---|
| first frame | 30s with no parsed CLI output at all |
| inactivity | 10m, reset on each parsed frame |

Both escalate `SIGTERM` → `SIGKILL` after 5s, so a CLI that ignores the first signal can't hold the host process open, and both are `unref`'d and cleared once the child exits. Activity is marked on a *parsed* frame, so noise on the pipe doesn't keep a dead run alive.

## On the test

The timeouts are injectable so this is testable. The test spawns a stand-in CLI that starts cleanly and then emits nothing, and asserts the harness fails fast with an error naming the actual condition — not a generic idle message.

**Mutation-verified**: disabling the first-frame watchdog makes that test hang until the runner's own 20s timeout, which is the bug reproduced.

Two things I had to fix in the test itself: it captured `process.stdout` wholesale, which swallowed node:test's own protocol frames (it now passes non-event writes through), and it asserted on `payload.message` where the harness emits `payload.error`.

## Noticed while here, not fixed

`harness-host`'s typecheck has **3 errors on `main`** (`consolidate-tool-family.test.ts`). CI runs `turbo run build test` for this package but **not `typecheck`**, so nothing catches them. Worth its own PR; flagging rather than silently expanding this one.

## Validation

- [x] `bun run test` (harness-host) — **285/285**
- [x] `bun run typecheck` — 3 errors, identical to clean `main` (see above)
- [x] New test mutation-verified
- [ ] Not exercised against a real wedged `claude` CLI — the stand-in reproduces the shape (starts, emits nothing) rather than a specific real-world stall

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)