### PR TITLE
ci(runtime): run the packages and the checks CI was skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,14 +138,27 @@ jobs:
           fi
           rg --version | head -1
 
-      - name: Runtime state store + harness host
+      # Covers every runtime package that isn't the api-server (which has its
+      # own job). runtime-harnesses and runtime-channel-gateway both have test
+      # scripts but appeared in no filter at all, so ~130 tests never ran —
+      # which is how a pi.test.ts assertion survived asserting the exact
+      # opposite of the live browser-tools policy.
+      #
+      # `typecheck` is included deliberately: this job ran `build test` only,
+      # so harness-host's tsc errors went unnoticed on main.
+      - name: Runtime packages (typecheck, build, test)
         # PI_OFFLINE makes the download path unreachable rather than merely
         # unused: if a tool is ever missing, the job fails immediately and
         # identically instead of flaking on whether a network call happened to
         # succeed. Combined with the install above, this step is hermetic.
         env:
           PI_OFFLINE: "1"
-        run: bunx turbo run build test --filter=@holaboss/runtime-state-store --filter=@holaboss/runtime-harness-host
+        run: >-
+          bunx turbo run typecheck build test
+          --filter=@holaboss/runtime-state-store
+          --filter=@holaboss/runtime-harness-host
+          --filter=@holaboss/runtime-harnesses
+          --filter=@holaboss/runtime-channel-gateway
 
   sdk-app-sdk:
     if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/apps/desktop/electron/release-channel-policy.test.mjs
+++ b/apps/desktop/electron/release-channel-policy.test.mjs
@@ -253,7 +253,12 @@ test("manual CI workflow publishes desktop installers without standalone runtime
   assert.match(builderConfig, /scripts", "write-app-update-config\.mjs"/);
   assert.match(builderConfig, /await writeAppUpdateConfig\(appBundlePath\);/);
   assert.match(source, /Desktop typecheck/);
-  assert.match(source, /Runtime state store \+ harness host/);
+  // Assert the coverage, not a step's prose label. This previously matched the
+  // step NAME, so renaming it failed here even when the rename ADDED packages —
+  // exactly backwards. Dropping a package from CI should fail this; relabelling
+  // a step should not.
+  assert.match(source, /--filter=@holaboss\/runtime-state-store/);
+  assert.match(source, /--filter=@holaboss\/runtime-harness-host/);
 });
 
 test("mac release helper runs zip + dmg in separate electron-builder passes and merges their manifests", async () => {

--- a/runtime/harness-host/src/consolidate-tool-family.test.ts
+++ b/runtime/harness-host/src/consolidate-tool-family.test.ts
@@ -10,7 +10,14 @@ function mk(
   name: string;
   description: string;
   parameters: Record<string, unknown>;
-  execute: (id: string, p: unknown) => Promise<{ called: string; params: unknown }>;
+  // pi's real signature is (toolCallId, toolParams, signal) — which is what
+  // consolidateOne forwards. Declaring only two here made the dispatcher's own
+  // call shape a type error in this file.
+  execute: (
+    id: string,
+    p: unknown,
+    signal?: AbortSignal,
+  ) => Promise<{ called: string; params: unknown }>;
 } {
   return {
     name,

--- a/runtime/harnesses/src/pi.test.ts
+++ b/runtime/harnesses/src/pi.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { piHarnessDefinition } from "./pi.js";
 
-test("pi harness enables browser tools only for executor sessions", () => {
+test("pi harness enables browser tools for every session kind except onboarding", () => {
   const buildHarnessHostRequest = piHarnessDefinition.runtimeAdapter.buildHarnessHostRequest;
   const baseParams = {
     request: {
@@ -74,7 +74,10 @@ test("pi harness enables browser tools only for executor sessions", () => {
 
   assert.equal(subagentRequest.browser_tools_enabled, true);
   assert.equal(subagentRequest.browser_space, "agent");
-  assert.equal(workspaceRequest.browser_tools_enabled, false);
+  // The main workspace loop gets browser tools too — its system prompt already
+  // advertises "direct access to … browser". browserToolsEnabledForSessionKind
+  // excludes only onboarding, so this asserted the reverse of the live policy.
+  assert.equal(workspaceRequest.browser_tools_enabled, true);
   assert.equal(workspaceRequest.browser_space, "agent");
   assert.equal(onboardingRequest.browser_tools_enabled, false);
   assert.equal(onboardingRequest.browser_space, null);
@@ -87,7 +90,18 @@ test("pi harness enables browser tools only for executor sessions", () => {
   assert.deepEqual(subagentRequest.context_messages, []);
   assert.deepEqual(workspaceRequest.context_messages, []);
   assert.deepEqual(onboardingRequest.context_messages, []);
-  assert.deepEqual(subagentRequest.tools, { read: true });
-  assert.deepEqual(workspaceRequest.tools, { read: true });
+  // Both agent-operating kinds get the browser tool family folded into `tools`;
+  // pinning the full list here would just re-break whenever a browser tool is
+  // added, so assert the property that matters.
+  for (const request of [subagentRequest, workspaceRequest]) {
+    const tools = request.tools as Record<string, boolean>;
+    assert.equal(tools.read, true);
+    assert.ok(
+      Object.keys(tools).some((name) => name.startsWith("browser_")),
+      "an agent-operating session should carry browser tools",
+    );
+  }
+  // Onboarding is the one exclusion — a constrained first-run flow with no
+  // place for browser control.
   assert.deepEqual(onboardingRequest.tools, { read: true });
 });


### PR DESCRIPTION
## Summary

Three gaps, all the same shape: **a check that exists and is never run.**

| Gap | Consequence |
|---|---|
| `runtime-harnesses` has a `test` script, appears in **no** turbo filter | ~55 tests never run |
| `runtime-channel-gateway` has a `test` script, appears in **no** filter | ~79 tests never run |
| The job covering state-store + harness-host ran `build test`, never `typecheck` | tsc errors accumulate unnoticed |

That combination is how `harness-host` ended up with **3 tsc errors on `main`**, and how a `pi.test.ts` assertion survived asserting the **exact opposite of the live policy**.

## What turning them on found

**1. A test asserting the reverse of the shipped behaviour.** `pi.test.ts` required `browser_tools_enabled === false` for a workspace session. But `browserToolsEnabledForSessionKind` deliberately excludes only onboarding — *"Every agent-operating session gets browser tools — the main workspace loop … as well as subagents."* The test encoded a policy that had been reversed.

It had **two** stale assertions, and the second was only visible after fixing the first, since `assert` stops at the first failure. The tools assertion now checks that agent-operating kinds carry the browser family rather than pinning all 34 tool names — pinning them would just re-break on the next browser tool added. The test is renamed too: *"only for executor sessions"* described the reverse of what it verifies.

**2. A fixture that made the real call shape a type error.** `consolidate-tool-family.test.ts` declared a 2-arg `execute` while the dispatcher forwards pi's real 3-arg signature (`toolCallId, toolParams, signal`, per the comment at `consolidate-tool-family.ts:89`). The test's 3-arg calls were correct; the annotation was stale.

## Scope check

I verified the other runtime packages typecheck clean **before** adding `typecheck` to the filter, so this can't turn CI red on something unrelated:

```
state-store       0 errors
harnesses         0 errors
channel-gateway   0 errors
harness-host      3 errors  → fixed here
```

And I ran the exact command CI will run rather than approximating it:

```
Tasks:    10 successful, 10 total
Time:     18.5s
```

## Dependency worth knowing

The search-tool tests in these packages call `ensureTool("rg" | "fd", true)`, which downloads on a cache miss — the intermittent CI failure fixed in **#489**. Merging that first makes this job deterministic; without it this job inherits the same flake.

## Validation

- [x] `harnesses` — 54/55 (1 pre-existing skip), was 53/55 with 1 failure
- [x] `harness-host` — 284/284, typecheck now **0 errors**
- [x] `channel-gateway` — 79/79
- [x] Exact CI command: 10/10 tasks
- [ ] `npm run desktop:typecheck` — not run; no desktop code touched

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)