### PR TITLE
fix(desktop): abort SSE streams when the main window closes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -26063,6 +26063,22 @@ function createMainWindow() {
     }
     closeAllFilePreviewWatchSubscriptions();
     stopComposioKeepWarm();
+    // Session/chat SSE connections are opened with `timeout: 0` because they
+    // are long-lived by design. Their only consumer is the renderer that just
+    // died, and on macOS ⌘W leaves the app running — so without this each
+    // open/close cycle stranded a never-timing-out socket to the runtime plus
+    // its reader closure, and emitSessionStreamEvent just logged
+    // "no windows" for the rest of the process's life.
+    //
+    // Aborting loses nothing: the run continues server-side and its events are
+    // persisted, so a reopened window re-attaches from the store.
+    for (const [streamId] of [...sessionOutputStreams]) {
+      void closeSessionOutputStream(streamId, "main_window_closed");
+    }
+    for (const controller of [...employeeChatStreams.values()]) {
+      controller.abort();
+    }
+    employeeChatStreams.clear();
     mainWindow = null;
   });
 }

--- a/apps/desktop/electron/window-close-stream-teardown.test.mjs
+++ b/apps/desktop/electron/window-close-stream-teardown.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+/**
+ * Session and employee-chat SSE requests are opened with `timeout: 0` because
+ * they are long-lived by design. Their only consumer is the main window's
+ * renderer, and on macOS ⌘W leaves the app running — so a window close that
+ * does not abort them strands a never-timing-out socket to the runtime, plus
+ * its reader closure, for the rest of the process's life. Every reopen adds
+ * another.
+ */
+
+test("closing the main window tears down its SSE streams", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  const index = source.indexOf('win.once("closed", () => {');
+  assert.notEqual(index, -1, "the main-window closed handler was not found");
+  const handler = source.slice(index, source.indexOf("\n  });", index));
+
+  assert.match(
+    handler,
+    /closeSessionOutputStream\(/,
+    "session output streams are no longer closed on window close",
+  );
+  assert.match(
+    handler,
+    /employeeChatStreams/,
+    "employee chat streams are no longer closed on window close",
+  );
+});
+
+test("the long-lived streams still opt out of a request timeout", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  // The counterpart to the teardown above: these are deliberately unbounded,
+  // which is exactly why closing the window has to abort them explicitly.
+  // If this ever gains a timeout, the teardown stops being load-bearing and
+  // this pair should be revisited together.
+  assert.match(
+    source,
+    /Session output uses a long-lived SSE connection[\s\S]{0,400}?timeout: 0/,
+    "the session output stream no longer documents its unbounded timeout",
+  );
+});


### PR DESCRIPTION
## Summary

Session-output and employee-chat SSE requests are opened with `timeout: 0` — deliberately, because they're long-lived:

```ts
// Session output uses a long-lived SSE connection. …
timeout: 0,
```

Their only consumer is the main window's renderer. But the window's `closed` handler tore down app-surface views, file-preview watchers and the composio keep-warm — and not these.

On macOS ⌘W leaves the app running, so **every close stranded a never-timing-out connection to the runtime**, plus its reader closure, and every reopen added another. `emitSessionStreamEvent` even notices — it logs `"no windows"` — but never aborted anything.

Aborting loses nothing: the run continues server-side and its events are persisted, so a reopened window re-attaches from the store. That's already how the renderer starts a stream on mount.

## Two things I deliberately did *not* change

I went in intending to fix quit-time process cleanup generally, and checked both candidates before touching them:

**Detached profile Chrome surviving quit is by design.** `launchProfileChromium` adopts an existing instance on the profile's fixed debug port:

> *"A Chrome may already be reachable on this profile's fixed debug port (it survived an app restart — our spawns are detached). Adopt it instead of spawning…"*

Killing those on quit would break a designed feature. It's a reasonable product question whether Quit should leave N owner-less Chrome windows with no UI to reclaim them — but that's a product call, not a leak to patch.

**The fingerprint service's `dispose()` is never called on quit** — only from `resetFingerprintEngineCache()` after a plugin install. That does look like a real gap. But the service is an EE plugin (`@holaboss/fingerprint-ee`) absent from this checkout, so whether disposing it also tears down engine-backed browsers a user expects to keep isn't verifiable from here. I'd rather leave it flagged than guess at cross-package behaviour I can't read.

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 121/121 (119 + 2 new)
- [x] Both teardowns **mutation-verified**: removing either loop fails a test
- [ ] Not reproduced live — verifying the socket leak means watching runtime connections across ⌘W/reopen cycles. The control flow is read directly from source.

The second test pins that these streams still opt *out* of a request timeout, since that's exactly what makes the teardown load-bearing — if they ever gain one, the pair should be revisited together.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)