### PR TITLE
perf(runtime): run pi's independent session-setup stages concurrently

### DIFF
--- a/runtime/harness-host/src/pi-session-setup.test.ts
+++ b/runtime/harness-host/src/pi-session-setup.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const piSourcePath = path.join(__dirname, "pi.ts");
+
+/**
+ * STRUCTURAL guard, deliberately.
+ *
+ * The four setup stages are module-level imports called inside createSession,
+ * and PiDeps only lets a caller replace createSession wholesale — so there is
+ * no seam to observe their concurrency from a test. What can be pinned is the
+ * shape: they must sit in one Promise.all. Re-introducing a sequential `await`
+ * is the regression this exists to catch, and it is a one-character change
+ * away at all times.
+ */
+
+const PARALLEL_SETUP_STAGES = [
+  "mcp_connect",
+  "runtime_tools",
+  "composio_inline",
+  "web_search",
+];
+
+test("the independent session-setup stages run concurrently", () => {
+  const source = fs.readFileSync(piSourcePath, "utf8");
+
+  const start = source.indexOf("await Promise.all([");
+  assert.notEqual(start, -1, "session setup no longer uses Promise.all");
+  const block = source.slice(start, source.indexOf("\n    ]);", start));
+
+  for (const stage of PARALLEL_SETUP_STAGES) {
+    assert.ok(
+      block.includes(`timedSetup("${stage}"`),
+      `${stage} is no longer part of the concurrent setup batch`,
+    );
+  }
+});
+
+test("no setup stage was re-serialized with its own await", () => {
+  const source = fs.readFileSync(piSourcePath, "utf8");
+
+  // `await timedSetup("mcp_connect", …)` outside the batch means someone put
+  // it back on the critical path. resource_reload and browser_tools are
+  // deliberately not in the batch, so they are not checked here.
+  for (const stage of PARALLEL_SETUP_STAGES) {
+    assert.ok(
+      !source.includes(`await timedSetup("${stage}"`),
+      `${stage} is awaited on its own again — session_setup pays the sum, not the max`,
+    );
+  }
+});

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -3008,37 +3008,49 @@ async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSe
   const sessionManager = persistedSessionFile
     ? SessionManager.open(persistedSessionFile, undefined, agentCwd)
     : SessionManager.create(agentCwd, sessionDir);
-  const mcpToolset = await timedSetup("mcp_connect", () =>
-    createPiMcpToolset(request),
-  );
+  // These four are independent — none consumes another's result — but they ran
+  // strictly one after another, so session_setup cost their SUM rather than
+  // their max. Each is network-ish (MCP discovery, the runtime tool catalogue,
+  // composio's inline listing, web-search definitions), and that time is paid
+  // before the model is contacted on every turn.
+  //
+  // Their timedSetup entries now overlap, so the per-stage numbers in
+  // `setup=[…]` will add up to more than the elapsed wall clock. That is the
+  // point; the individual durations are still what you want when deciding
+  // which one to attack next.
+  const [mcpToolset, resolvedRuntimeTools, composioInline, webSearchTools] =
+    await Promise.all([
+      timedSetup("mcp_connect", () => createPiMcpToolset(request)),
+      timedSetup("runtime_tools", () =>
+        resolveHarnessRuntimeToolDefinitions({
+          runtimeApiBaseUrl: request.runtime_api_base_url,
+          workspaceId: request.workspace_id,
+          sessionId: request.session_id,
+          inputId: request.input_id,
+          selectedModel: runtimeToolSelectedModelForPiRequest(request),
+        }),
+      ),
+      timedSetup("composio_inline", () =>
+        resolveComposioInlineTools({
+          workspaceDir: request.workspace_dir,
+          runtimeApiBaseUrl: request.runtime_api_base_url ?? null,
+          workspaceId: request.workspace_id,
+          sessionId: request.session_id,
+          inputId: request.input_id,
+          selectedModel: runtimeToolSelectedModelForPiRequest(request) ?? null,
+        }),
+      ),
+      toolEnabledForPiRequest(request, "web_search")
+        ? timedSetup("web_search", () => resolvePiWebSearchToolDefinitions())
+        : Promise.resolve([]),
+    ]);
   const runtimeTools = filterPiToolDefinitionsForRequest(
     request,
-    await timedSetup("runtime_tools", () =>
-      resolveHarnessRuntimeToolDefinitions({
-        runtimeApiBaseUrl: request.runtime_api_base_url,
-        workspaceId: request.workspace_id,
-        sessionId: request.session_id,
-        inputId: request.input_id,
-        selectedModel: runtimeToolSelectedModelForPiRequest(request),
-      })
-    )
+    resolvedRuntimeTools,
   );
   const runtimeToolsForHost = consolidateRuntimeToolFamilies(
     filterPiRuntimeToolDefinitionsForHost(runtimeTools),
   );
-  const composioInline = await timedSetup("composio_inline", () =>
-    resolveComposioInlineTools({
-      workspaceDir: request.workspace_dir,
-      runtimeApiBaseUrl: request.runtime_api_base_url ?? null,
-      workspaceId: request.workspace_id,
-      sessionId: request.session_id,
-      inputId: request.input_id,
-      selectedModel: runtimeToolSelectedModelForPiRequest(request) ?? null,
-    }),
-  );
-  const webSearchTools = toolEnabledForPiRequest(request, "web_search")
-    ? await timedSetup("web_search", () => resolvePiWebSearchToolDefinitions())
-    : [];
   // agentCwd resolved at the top of this function. All agent-facing tools
   // (Bash via createCodingTools, Ls, find, search, document-read) get
   // wired to agentCwd as their root. workspace_dir keeps feeding the


### PR DESCRIPTION
## Summary

`createSession` awaited four setup stages strictly one after another (`pi.ts:3011`–`:3040`):

| Stage | What it does |
|---|---|
| `mcp_connect` | MCP server discovery |
| `runtime_tools` | the runtime tool catalogue |
| `composio_inline` | composio's inline tool listing |
| `web_search` | web-search tool definitions |

**None consumes another's result**, so `session_setup` cost their **sum** rather than their max. All four are network-ish, and that time is paid before the model is contacted on *every* turn.

They now run in one `Promise.all`. The only ordering that mattered — `runtimeTools` feeding `filterPiToolDefinitionsForRequest` and then `consolidateRuntimeToolFamilies` — is synchronous and stays after the batch.

## One consequence worth knowing

The `timedSetup` entries now overlap, so the per-stage numbers in `setup=[…]` will add up to **more** than the elapsed wall clock. That's expected rather than a bug in the instrumentation, and the individual durations are still the useful thing when deciding which stage to attack next. I checked `timedSetup` writes a distinct key per stage before doing this, so concurrent stages can't clobber each other's timing.

## The test is structural, and says so

I looked for a way to observe the concurrency directly and there isn't one: these are module-level imports called inside `createSession`, and `PiDeps` only lets a caller swap `createSession` wholesale. So rather than dress up a weak test, the guard pins the shape — the four stay in one `Promise.all`, and none regains its own `await`.

That's the regression it exists to catch, and it's one character away at any time. **Mutation-verified** by pulling `composio_inline` back out, which fails with *"composio_inline is awaited on its own again — session_setup pays the sum, not the max"*.

I've been critical of source-snapshot tests elsewhere in this stack, so to be explicit about the difference: this one pins a structural property that *is* the behaviour, not a formatting choice or a call shape that could change harmlessly.

## Validation

- [x] `bun run test` (harness-host) — **286/286** (284 + 2 new)
- [x] `bun run typecheck` — 3 errors, identical to clean `main` (they're fixed in #495)
- [x] Re-serialization mutation-verified
- [ ] Not measured end-to-end. The win is structural — four independent awaits become one — but I have no TTFT numbers from a real run to quote, and I'd rather say so than imply I measured it.

Related: the TTFT design doc (`runtime/docs/plans/2026-08-13-warm-harness-ttft-init.md`) attributes the larger cost to two cold Node spawns per turn, which this does **not** address. This is the smaller, contained half.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)