### PR TITLE
fix(runtime): give the streaming runner endpoint the watchdogs it lacked

### DIFF
--- a/runtime/api-server/src/runner-worker.test.ts
+++ b/runtime/api-server/src/runner-worker.test.ts
@@ -725,3 +725,31 @@ test("a custom runner template still inlines the base64 request (no file)", () =
     "template inlines the base64 request as before",
   );
 });
+
+test("native runner executor stream gives up on a wedged runner", async () => {
+  // Emits one real event and then hangs forever. Before the stream endpoint
+  // had watchdogs this produced `: ping` keepalives indefinitely — a
+  // healthy-looking stream that never reached a terminal event and never
+  // errored, so the caller waited on it for as long as the process lived.
+  setNodeRunnerTemplate([
+    "process.stdout.write(JSON.stringify({ session_id: 'session-1', input_id: 'input-1', sequence: 1, event_type: 'run_started', payload: { instruction_preview: 'hello' } }) + '\\n');",
+    "setInterval(() => {}, 1000);"
+  ]);
+  process.env.SANDBOX_AGENT_RUN_IDLE_TIMEOUT_S = "1";
+
+  const executor = new NativeRunnerExecutor();
+  const startedAt = Date.now();
+  const stream = await executor.stream(payload());
+  let body = "";
+  for await (const chunk of stream) {
+    body += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+  }
+  const elapsed = Date.now() - startedAt;
+
+  assert.match(body, /event: run_started/);
+  assert.match(body, /event: run_failed/);
+  // Named, not generic: "ended before terminal event" would not tell an
+  // operator that the runner stalled rather than exited.
+  assert.match(body, /became idle for 1s without a terminal event/);
+  assert.ok(elapsed < 30_000, `stream should end on its own deadline, took ${elapsed}ms`);
+});

--- a/runtime/api-server/src/runner-worker.ts
+++ b/runtime/api-server/src/runner-worker.ts
@@ -1014,6 +1014,47 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
     let lastSequence = 0;
     let heartbeat: NodeJS.Timeout | null = null;
 
+    // The heartbeat below only pushes `: ping` — it proves the HTTP connection
+    // is alive, not that the runner is. Without the two watchdogs that
+    // executeRunnerRequest has, a wedged runner emitted pings forever and the
+    // caller saw a healthy-looking stream that never produced a terminal event
+    // and never errored. Mirror them here so the streaming endpoint fails the
+    // same way, with the same wording, as the non-streaming one.
+    let timedOut = false;
+    let idleTimedOut = false;
+    const hardTimeoutMs = runnerTimeoutSeconds(payload) * 1000;
+    const idleTimeoutMs = runnerIdleTimeoutSeconds(payload) * 1000;
+    const hardTimeout = setTimeout(() => {
+      if (sawTerminal) {
+        return;
+      }
+      timedOut = true;
+      killChildProcess(child, "SIGKILL");
+    }, Math.max(1, hardTimeoutMs));
+    hardTimeout.unref?.();
+    let idleTimeout: NodeJS.Timeout | null = null;
+    const clearWatchdogs = () => {
+      clearTimeout(hardTimeout);
+      if (idleTimeout) {
+        clearTimeout(idleTimeout);
+        idleTimeout = null;
+      }
+    };
+    const resetIdleTimeout = () => {
+      if (idleTimeout) {
+        clearTimeout(idleTimeout);
+      }
+      idleTimeout = setTimeout(() => {
+        if (sawTerminal) {
+          return;
+        }
+        idleTimedOut = true;
+        killChildProcess(child, "SIGKILL");
+      }, idleTimeoutMs);
+      idleTimeout.unref?.();
+    };
+    resetIdleTimeout();
+
     const resetHeartbeat = () => {
       if (heartbeat) {
         clearTimeout(heartbeat);
@@ -1054,10 +1095,14 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
         }
         stream.push(sseEvent(parsed));
         resetHeartbeat();
+        // A parsed event is real progress; a heartbeat is not, which is why
+        // the idle watchdog resets here and not in resetHeartbeat.
+        resetIdleTimeout();
         if (sawTerminal) {
           if (heartbeat) {
             clearTimeout(heartbeat);
           }
+          clearWatchdogs();
           killChildProcess(child, "SIGTERM");
         }
       }
@@ -1067,6 +1112,7 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
       if (heartbeat) {
         clearTimeout(heartbeat);
       }
+      clearWatchdogs();
       const trailingLine = stdoutBuffer.trim();
       if (trailingLine) {
         const parsed = parseRunnerEventLine(trailingLine);
@@ -1084,10 +1130,13 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
         const stderrText = Buffer.concat(stderrChunks).toString("utf-8").trim();
         const details = skippedLines.length > 0 ? skippedLines.slice(0, 3).join("; ") : "";
         const suffix = details ? ` (skipped output: ${details})` : "";
-        const message =
-          returnCode !== 0
-            ? stderrText || `runner command failed with exit_code=${returnCode}`
-            : `runner stream ended before terminal event${suffix}`;
+        const message = timedOut
+          ? "runner command timed out"
+          : idleTimedOut
+            ? `runner command became idle for ${Math.round(idleTimeoutMs / 1000)}s without a terminal event`
+            : returnCode !== 0
+              ? stderrText || `runner command failed with exit_code=${returnCode}`
+              : `runner stream ended before terminal event${suffix}`;
         const event = buildRunFailedEvent({
           sessionId: requiredString(payload, "session_id"),
           inputId: requiredString(payload, "input_id"),
@@ -1112,6 +1161,9 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
       if (heartbeat) {
         clearTimeout(heartbeat);
       }
+      // The consumer went away; the child is being killed, so the watchdogs
+      // have nothing left to guard.
+      clearWatchdogs();
       if (!child.killed) {
         killChildProcess(child, "SIGTERM");
       }


### PR DESCRIPTION
## Summary

`NativeRunnerExecutor.stream()` had a heartbeat and nothing else.

The heartbeat only pushes `: ping` — it proves the **HTTP connection** is alive, not that the runner is. So a wedged runner on `POST /api/v1/agent-runs/stream` emitted keepalives indefinitely, and the caller saw a healthy-looking stream that never produced a terminal event and never errored.

`executeRunnerRequest` — the non-streaming path — has had both a hard deadline (`:726`) and an idle watchdog (`:738`) all along. This mirrors them, **including the wording**, so the two paths fail identically:

```
runner command timed out
runner command became idle for Ns without a terminal event
```

## Why this is a small change

`finalize()` already synthesizes a `run_failed` when the stream ends without a terminal event. So killing the child is enough to produce a proper terminal event rather than a truncated stream — no new failure plumbing needed. I checked that `child.once("close", (code) => finalize(code ?? 0))` passes `0` on SIGKILL, so the timeout branch has to come first in the message ladder, which it does.

## Two details worth reviewing

- **The idle watchdog resets on a parsed event, not in `resetHeartbeat`.** A keepalive is not progress; resetting on it would defeat the entire mechanism. This is the same distinction codex's harness draws between activity and heartbeat notifications.
- **Watchdogs are cleared when the consumer disconnects** (`stream.once("close")`), where the child is being killed anyway and there's nothing left to guard.

## Validation

- [x] `bun run typecheck` (api-server) — clean
- [x] `runner-worker.test.ts` — **27/27** (26 + 1 new)
- [x] **Mutation-verified**: disabling the idle watchdog makes the new test hang until the test runner's own 15s timeout — the bug reproduced rather than a proxy for it
- [ ] Not exercised against a real wedged runner; the test's stand-in emits one real event and then hangs, which is the shape

The test asserts the *named* failure (`became idle for 1s…`), not just that a `run_failed` appears — a generic "ended before terminal event" wouldn't tell an operator the runner stalled rather than exited, which was half the original problem.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)