### PR TITLE
fix(desktop): re-enable background throttling after the surface prewarm

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18964,6 +18964,14 @@ async function prewarmWebHolaAppSurface(holaAppId: string): Promise<void> {
         }
       },
     );
+    // The opt-out above is for the LOAD, per its comment — but nothing ever put
+    // it back, so a detached, invisible page kept running its timers,
+    // animations and polling at full cadence for the rest of the app session.
+    // Restoring the default only affects the view while it is hidden or
+    // occluded; an attached, visible surface is not throttled by Chromium.
+    if (!view.webContents.isDestroyed()) {
+      view.webContents.setBackgroundThrottling(true);
+    }
   } catch (err) {
     console.warn(`[web-holaapp] prewarm ${holaAppId} failed:`, err);
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18953,24 +18953,32 @@ async function prewarmWebHolaAppSurface(holaAppId: string): Promise<void> {
     appSurfaceIdentity.set(view.webContents.id, { appId: holaAppId });
     // Keep it responsive while detached so the prewarm load isn't background-throttled.
     view.webContents.setBackgroundThrottling(false);
-    await seedAppSurfaceAuthCookies(view.webContents.session);
-    console.log(`[web-holaapp] prewarming ${holaAppId} → ${targetUrl}`);
-    await view.webContents.loadURL(targetUrl).then(
-      () => console.log(`[web-holaapp] ${holaAppId} prewarmed`),
-      (err: unknown) => {
-        const code = (err as { code?: unknown } | null)?.code;
-        if (code !== "ERR_ABORTED") {
-          console.warn(`[web-holaapp] prewarm ${holaAppId} load error:`, err);
-        }
-      },
-    );
-    // The opt-out above is for the LOAD, per its comment — but nothing ever put
-    // it back, so a detached, invisible page kept running its timers,
-    // animations and polling at full cadence for the rest of the app session.
-    // Restoring the default only affects the view while it is hidden or
-    // occluded; an attached, visible surface is not throttled by Chromium.
-    if (!view.webContents.isDestroyed()) {
-      view.webContents.setBackgroundThrottling(true);
+    try {
+      await seedAppSurfaceAuthCookies(view.webContents.session);
+      console.log(`[web-holaapp] prewarming ${holaAppId} → ${targetUrl}`);
+      await view.webContents.loadURL(targetUrl).then(
+        () => console.log(`[web-holaapp] ${holaAppId} prewarmed`),
+        (err: unknown) => {
+          const code = (err as { code?: unknown } | null)?.code;
+          if (code !== "ERR_ABORTED") {
+            console.warn(`[web-holaapp] prewarm ${holaAppId} load error:`, err);
+          }
+        },
+      );
+    } finally {
+      // The opt-out above is for the LOAD, per its comment — but nothing ever
+      // put it back, so a detached, invisible page kept running its timers,
+      // animations and polling at full cadence for the rest of the app
+      // session. Restoring the default only affects the view while it is
+      // hidden or occluded; an attached, visible surface is not throttled by
+      // Chromium.
+      //
+      // In a `finally`, not at the end of the try: the cookie seed above can
+      // reject, and the outer catch only logs — so on that path the opt-out
+      // would otherwise be permanent, which is the leak this exists to close.
+      if (!view.webContents.isDestroyed()) {
+        view.webContents.setBackgroundThrottling(true);
+      }
     }
   } catch (err) {
     console.warn(`[web-holaapp] prewarm ${holaAppId} failed:`, err);

--- a/apps/desktop/electron/prewarm-throttling.test.mjs
+++ b/apps/desktop/electron/prewarm-throttling.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSourcePath = path.join(__dirname, "main.ts");
+
+/**
+ * The prewarmed HolaEmployee surface is created detached and never shown until
+ * the user opens it. Background throttling is turned off so the prewarm LOAD
+ * runs at full speed — but leaving it off means an invisible page keeps its
+ * timers, animations and polling running at full cadence for the whole app
+ * session, whether or not the user ever opens that surface.
+ */
+
+test("prewarming restores background throttling once the load finishes", async () => {
+  const source = await readFile(mainSourcePath, "utf8");
+
+  const start = source.indexOf("async function prewarmWebHolaAppSurface");
+  assert.notEqual(start, -1, "prewarmWebHolaAppSurface was not found");
+  const fn = source.slice(start, source.indexOf("\n}\n", start));
+
+  const disableAt = fn.indexOf("setBackgroundThrottling(false)");
+  const restoreAt = fn.indexOf("setBackgroundThrottling(true)");
+
+  assert.notEqual(disableAt, -1, "the prewarm no longer opts out of throttling");
+  assert.notEqual(
+    restoreAt,
+    -1,
+    "the prewarm never restores background throttling — the detached surface runs at full cadence forever",
+  );
+  // Order matters: restoring before the load would defeat the opt-out.
+  assert.ok(
+    restoreAt > disableAt,
+    "throttling must be restored after the load, not before it",
+  );
+});

--- a/apps/desktop/electron/prewarm-throttling.test.mjs
+++ b/apps/desktop/electron/prewarm-throttling.test.mjs
@@ -36,4 +36,24 @@ test("prewarming restores background throttling once the load finishes", async (
     restoreAt > disableAt,
     "throttling must be restored after the load, not before it",
   );
+
+  // …and it has to be unconditional. Everything between the opt-out and the
+  // restore can throw — seedAppSurfaceAuthCookies rejects, the view is
+  // destroyed mid-prewarm — and the enclosing catch only logs, so a restore
+  // sitting on the success path leaves the opt-out permanent on exactly the
+  // failures this guards against.
+  const finallyAt = fn.indexOf("} finally {");
+  assert.notEqual(
+    finallyAt,
+    -1,
+    "the restore is not in a finally — a throw during the prewarm leaks the opt-out for the rest of the session",
+  );
+  assert.ok(
+    restoreAt > finallyAt,
+    "background throttling must be restored inside the finally, not on the success path",
+  );
+  assert.ok(
+    disableAt < finallyAt,
+    "the opt-out must happen before the guarded block it is undone by",
+  );
 });


### PR DESCRIPTION
## Summary

`prewarmWebHolaAppSurface` turns background throttling off:

```ts
// Keep it responsive while detached so the prewarm load isn't background-throttled.
view.webContents.setBackgroundThrottling(false);
```

The comment scopes it to **the load**. Nothing ever put it back:

```
$ rg setBackgroundThrottling apps/desktop/electron/main.ts
18955:    view.webContents.setBackgroundThrottling(false);
```

One call site, and no `(true)` anywhere.

So the prewarmed HolaEmployee surface — created **detached** on shell mount, never shown until the user opens it — kept its timers, animations and polling running at full cadence for the entire app session, whether or not the user ever opened it. An invisible page, at full speed, forever.

## Why this is safe

Restoring the default only affects the view **while it is hidden or occluded**. An attached, visible surface isn't throttled by Chromium, so opening the surface behaves exactly as before — the prewarm still loads unthrottled, which is what the opt-out was for.

Guarded on `isDestroyed()`: the prewarm can lose its view to a renderer crash mid-load, and the `render-process-gone` handler already destroys the entry.

The guard test also asserts the **order** — restoring before the load would defeat the opt-out entirely, which is a plausible way for someone to "fix" this wrongly.

## Deliberately not in this PR

`appSurfaceViews` retains every opened surface for the window's lifetime, so opening N HolaApps leaves N resident Chromium renderer processes (third-party surfaces like Notion keep their own timers and websockets alive behind the scenes).

I looked at capping it with an LRU and decided against bundling it here. The retention is partly **deliberate** — the code calls it a "kept-alive view", so re-opening is instant — and any cap has to avoid evicting the active surface and the prewarm target. Getting that wrong surfaces as a broken app pane, which is a worse outcome than the memory it saves. It deserves its own PR and its own review.

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 120/120 (119 + 1 new)
- [x] **Mutation-verified**: removing the restore fails the guard
- [ ] Not measured. I haven't profiled the CPU the detached surface actually draws — the fix is that an invisible page shouldn't be exempt from throttling at all, independent of magnitude.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)