### PR TITLE
fix(desktop): open Model Providers from the Model Providers control

### DIFF
--- a/apps/desktop/electron/authPopupPreload.ts
+++ b/apps/desktop/electron/authPopupPreload.ts
@@ -86,7 +86,24 @@ interface WorkspaceListResponsePayload {
   offset: number;
 }
 
-type UiSettingsPaneSection = "account" | "billing" | "providers" | "integrations" | "submissions" | "settings" | "about";
+// Sections the settings screen can actually render (SettingsScreenRoot's
+// SETTINGS_NAV + its submissions branch). Kept identical in main.ts,
+// preload.ts, authPopupPreload.ts and electron.d.ts.
+//
+// These four had drifted to four different lists, and three of the values they
+// carried between them — "providers", "integrations", "about" — matched no
+// render branch at all, so passing one opened Settings with a blank pane and
+// no nav item selected.
+type UiSettingsPaneSection =
+  | "account"
+  | "agents"
+  | "billing"
+  | "byok"
+  | "channels"
+  | "experimental"
+  | "memory"
+  | "settings"
+  | "submissions";
 
 const INTERNAL_DEV_BACKEND_OVERRIDES_ENABLED =
   Boolean(process.env.VITE_DEV_SERVER_URL) || process.env.HOLABOSS_INTERNAL_DEV?.trim() === "1";

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1132,14 +1132,45 @@ interface BrowserAnchorBoundsPayload {
   height: number;
 }
 
+// Sections the settings screen can actually render (SettingsScreenRoot's
+// SETTINGS_NAV + its submissions branch). Kept identical in main.ts,
+// preload.ts, authPopupPreload.ts and electron.d.ts.
+//
+// These four had drifted to four different lists, and three of the values they
+// carried between them — "providers", "integrations", "about" — matched no
+// render branch at all, so passing one opened Settings with a blank pane and
+// no nav item selected.
 type UiSettingsPaneSection =
   | "account"
+  | "agents"
   | "billing"
-  | "providers"
-  | "integrations"
-  | "submissions"
+  | "byok"
+  | "channels"
+  | "experimental"
+  | "memory"
   | "settings"
-  | "about";
+  | "submissions";
+
+const UI_SETTINGS_PANE_SECTIONS: readonly UiSettingsPaneSection[] = [
+  "account",
+  "agents",
+  "billing",
+  "byok",
+  "channels",
+  "experimental",
+  "memory",
+  "settings",
+  "submissions",
+];
+
+/** Unknown sections fall back to General rather than opening a blank pane. */
+function normalizeUiSettingsPaneSection(
+  section: unknown,
+): UiSettingsPaneSection {
+  return UI_SETTINGS_PANE_SECTIONS.includes(section as UiSettingsPaneSection)
+    ? (section as UiSettingsPaneSection)
+    : "settings";
+}
 
 interface AddressSuggestionPayload {
   id: string;
@@ -27581,7 +27612,7 @@ app.whenReady().then(async () => {
     "ui:openSettingsPane",
     ["main", "auth-popup"],
     async (_event, section?: UiSettingsPaneSection) => {
-      emitOpenSettingsPane(section ?? "settings");
+      emitOpenSettingsPane(normalizeUiSettingsPaneSection(section));
       if (mainWindow && !mainWindow.isDestroyed()) {
         if (mainWindow.isMinimized()) {
           mainWindow.restore();

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -166,15 +166,24 @@ interface BrowserAnchorBoundsPayload {
 	height: number;
 }
 
+// Sections the settings screen can actually render (SettingsScreenRoot's
+// SETTINGS_NAV + its submissions branch). Kept identical in main.ts,
+// preload.ts, authPopupPreload.ts and electron.d.ts.
+//
+// These four had drifted to four different lists, and three of the values they
+// carried between them — "providers", "integrations", "about" — matched no
+// render branch at all, so passing one opened Settings with a blank pane and
+// no nav item selected.
 type UiSettingsPaneSection =
 	| "account"
+	| "agents"
 	| "billing"
-	| "providers"
-	| "integrations"
+	| "byok"
+	| "channels"
+	| "experimental"
 	| "memory"
-	| "submissions"
 	| "settings"
-	| "experimental";
+	| "submissions";
 
 interface DesktopWindowStatePayload {
 	isFullScreen: boolean;

--- a/apps/desktop/src/components/layout/SettingsScreenRoot.tsx
+++ b/apps/desktop/src/components/layout/SettingsScreenRoot.tsx
@@ -125,8 +125,12 @@ function pageTitle(section: UiSettingsPaneSection): string {
       return "Billing";
     case "agents":
       return "Agents";
-    case "integrations":
-      return "Connections";
+    // "byok" had no case, so the Model Providers pane rendered under the
+    // fallback heading "General". "integrations" had one and no render branch —
+    // a title over an empty pane — and is gone with the rest of the dead
+    // sections.
+    case "byok":
+      return "Model Providers";
     case "channels":
       return "Channels";
     case "memory":

--- a/apps/desktop/src/components/panes/ChatPane.test.mjs
+++ b/apps/desktop/src/components/panes/ChatPane.test.mjs
@@ -124,7 +124,7 @@ test("chat pane shows provider setup CTA when no chat models are available", asy
   );
   assert.match(
     source,
-    /onOpenModelProviders=\{\(\) =>[\s\S]*window\.electronAPI\.ui\.openSettingsPane\("providers"\)[\s\S]*\}/,
+    /onOpenModelProviders=\{\(\) =>[\s\S]*window\.electronAPI\.ui\.openSettingsPane\(\s*"byok",?\s*\)[\s\S]*\}/,
   );
   assert.match(source, /aria-label="Configure model providers"/);
   assert.match(

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -10399,7 +10399,7 @@ export function ChatPane({
                                 onThinkingValueChange={composerOnThinkingValueChange}
                                 onOpenModelProviders={() =>
                                   void window.electronAPI.ui.openSettingsPane(
-                                    "account",
+                                    "byok",
                                   )
                                 }
                                 fileInputRef={fileInputRef}
@@ -10677,7 +10677,7 @@ export function ChatPane({
                           onThinkingValueChange={composerOnThinkingValueChange}
                           onOpenModelProviders={() =>
                             void window.electronAPI.ui.openSettingsPane(
-                              "account",
+                              "byok",
                             )
                           }
                           fileInputRef={fileInputRef}

--- a/apps/desktop/src/components/projects/ProjectLanding.tsx
+++ b/apps/desktop/src/components/projects/ProjectLanding.tsx
@@ -849,7 +849,7 @@ export function ProjectLanding({
                     : setHarnessThinkingOverride
                 }
                 onOpenModelProviders={() =>
-                  void window.electronAPI.ui.openSettingsPane("account")
+                  void window.electronAPI.ui.openSettingsPane("byok")
                 }
                 fileInputRef={fileInputRef}
                 onAttachmentInputChange={onAttachmentInputChange}

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -172,18 +172,19 @@ declare global {
 		height: number;
 	}
 
+	// Sections the settings screen can actually render (SettingsScreenRoot's
+	// SETTINGS_NAV + its submissions branch). Kept identical in main.ts,
+	// preload.ts, authPopupPreload.ts and here.
 	type UiSettingsPaneSection =
 		| "account"
+		| "agents"
 		| "billing"
 		| "byok"
-		| "providers"
-		| "agents"
-		| "integrations"
 		| "channels"
+		| "experimental"
 		| "memory"
-		| "submissions"
 		| "settings"
-		| "experimental";
+		| "submissions";
 
 	interface MemoryBrowserTreeNodePayload {
 		name: string;


### PR DESCRIPTION
## Summary

The composer's **"Configure model providers"** affordance called `openSettingsPane("account")`, so it landed on **Account**. It sits in the *"you have no model configured"* escape hatch, so it's mostly new users who hit it. `ProjectLanding` had the same.

It couldn't have been right, because `"byok"` — the section actually labelled **"Model Providers"** in `SETTINGS_NAV` — was **missing from the `UiSettingsPaneSection` union** that `main.ts` and the preloads declare. A caller typing against those had no correct value to pass.

## The drift behind it

Four declarations of the same union, no two alike:

| File | Members |
|---|---:|
| `main.ts` | 7 |
| `authPopupPreload.ts` | 7 |
| `preload.ts` | 8 |
| `electron.d.ts` | 11 |

Three of the values they carried between them — `providers`, `integrations`, `about` — match **no render branch** in `SettingsScreenRoot`. Passing any of them opened Settings with a blank pane and nothing selected.

All four now match what the screen can actually render, and the IPC handler normalizes an unknown section to `"settings"` rather than forwarding it raw — so this can't silently reappear.

## Aligning the types immediately surfaced two more bugs

This is the part I'd flag for review, because neither was visible before:

1. `pageTitle` had `case "integrations": return "Connections"` — a heading with **no pane behind it**. The typecheck failed on it the moment the union was tightened, which is how I found it.
2. `pageTitle` had **no case for `"byok"` at all**, so the Model Providers pane rendered under the fallback heading **"General"**. Fixing the link alone would have produced the right pane with the wrong title — a half-fix that would have looked done.

## Validation

- [x] `npm run desktop:typecheck` — clean (and it caught #1 above mid-change)
- [x] `bun run test:electron` — 119/119
- [x] `src/**/*.test.{ts,tsx}` — 184/186; the 2 failures are the `turnResultCards` pair fixed in #487
- [x] Verified the updated `ChatPane.test.mjs` assertion actually matches the new source (2 occurrences), rather than assuming
- [ ] Not clicked through in the running app. The routing is a literal string change against `SETTINGS_NAV`'s own ids, but the visual result is unverified by me — say the word if you'd like me to launch it and check.

`ChatPane.test.mjs` pinned a **third** value again (`"providers"`). It's in the rotted `src/**/*.test.mjs` tier and is **31/50 before and after** this change — I checked against clean `main` so I'm not claiming an improvement I didn't make.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)