### PR TITLE
perf(desktop): stop re-highlighting a code block on every streamed frame

### DIFF
--- a/apps/desktop/src/components/marketplace/CodeBlock.tsx
+++ b/apps/desktop/src/components/marketplace/CodeBlock.tsx
@@ -162,7 +162,15 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
   const isLong = lineCount > LONG_BLOCK_LINE_THRESHOLD;
   const [expanded, setExpanded] = useState(!isLong);
   const [copied, setCopied] = useState(false);
-  const [highlighted, setHighlighted] = useState<string | null>(null);
+  // Carries the key it was produced for. Holding the HTML alone let a commit
+  // paint the PREVIOUS body's highlight: when the settle timer fires,
+  // `settledCode === trimmed` becomes true in the same commit that still holds
+  // the older HTML, so a streaming block flashed its earlier, shorter self
+  // before the effect could clear it.
+  const [highlighted, setHighlighted] = useState<{
+    key: string;
+    html: string;
+  } | null>(null);
   const [theme, setTheme] = useState(pickShikiTheme);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -225,10 +233,11 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
   useEffect(() => {
     const cached = highlightCache.get(cacheKey);
     if (cached) {
-      setHighlighted(cached);
+      setHighlighted({ key: cacheKey, html: cached });
       return;
     }
-    setHighlighted(null);
+    // No clear needed: the render gates on the stored key, so stale HTML is
+    // already invisible. Clearing here would only cost an extra render.
     if (!inView) return;
 
     let cancelled = false;
@@ -244,7 +253,7 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
           if (firstKey !== undefined) highlightCache.delete(firstKey);
         }
         highlightCache.set(cacheKey, html);
-        setHighlighted(html);
+        setHighlighted({ key: cacheKey, html });
       } catch {
         if (!cancelled) setHighlighted(null);
       }
@@ -286,13 +295,15 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
         </button>
       </div>
       {/* Only show highlighted HTML when it corresponds to the text on screen.
-          While the body is still growing, settledCode lags `trimmed`, and
-          rendering the stale highlight would freeze a streaming block at an
-          earlier frame. The plain <pre> below stays live throughout. */}
-      {highlighted && settledCode === trimmed ? (
+          Two conditions, and both are load-bearing: the HTML must have been
+          produced for the CURRENT key (otherwise the commit in which
+          settledCode catches up paints the previous body), and settledCode
+          must have caught up at all (otherwise a still-growing block freezes
+          at an earlier frame). The plain <pre> below stays live throughout. */}
+      {highlighted?.key === cacheKey && settledCode === trimmed ? (
         <div
           className={`md-code-block-shiki ${expanded ? "" : "md-code-block-collapsed"}`.trim()}
-          dangerouslySetInnerHTML={{ __html: highlighted }}
+          dangerouslySetInnerHTML={{ __html: highlighted.html }}
         />
       ) : (
         <pre

--- a/apps/desktop/src/components/marketplace/CodeBlock.tsx
+++ b/apps/desktop/src/components/marketplace/CodeBlock.tsx
@@ -11,6 +11,12 @@ import { type BundledLanguage, bundledLanguages, codeToHtml } from "shiki";
 
 const LONG_BLOCK_LINE_THRESHOLD = 30;
 const HIGHLIGHT_CACHE_MAX = 200;
+/**
+ * How long the code body must stop changing before it is worth tokenizing.
+ * Streaming output changes far faster than this, so a block being written is
+ * highlighted once at the end rather than on every frame.
+ */
+const HIGHLIGHT_SETTLE_MS = 120;
 const highlightCache = new Map<string, string>();
 
 const LANGUAGE_ALIASES: Record<string, BundledLanguage> = {
@@ -82,6 +88,39 @@ function pickShikiTheme(): "vitesse-dark" | "vitesse-light" {
   return themeAttr.toLowerCase().includes("dark") ? "vitesse-dark" : "vitesse-light";
 }
 
+/**
+ * One MutationObserver on <html> for the whole app, not one per code block.
+ * A long conversation renders many CodeBlocks, and each used to observe the
+ * root element itself — the theme changes at most a handful of times per
+ * session, so N observers for one shared signal is pure overhead.
+ */
+type ShikiTheme = ReturnType<typeof pickShikiTheme>;
+const themeSubscribers = new Set<(theme: ShikiTheme) => void>();
+let rootThemeObserver: MutationObserver | null = null;
+
+function subscribeShikiTheme(onChange: (theme: ShikiTheme) => void): () => void {
+  themeSubscribers.add(onChange);
+  if (!rootThemeObserver && typeof MutationObserver !== "undefined") {
+    rootThemeObserver = new MutationObserver(() => {
+      const next = pickShikiTheme();
+      for (const subscriber of themeSubscribers) {
+        subscriber(next);
+      }
+    });
+    rootThemeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme", "class"],
+    });
+  }
+  return () => {
+    themeSubscribers.delete(onChange);
+    if (themeSubscribers.size === 0) {
+      rootThemeObserver?.disconnect();
+      rootThemeObserver = null;
+    }
+  };
+}
+
 function extractText(node: ReactNode): string {
   if (node === null || node === undefined || typeof node === "boolean") return "";
   if (typeof node === "string") return node;
@@ -131,17 +170,30 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
   const resolvedLanguage =
     explicitLanguage === "text" ? detectLanguage(trimmed) : explicitLanguage;
 
-  const cacheKey = `${theme}:${resolvedLanguage}:${trimmed}`;
+  // Highlight the text once it SETTLES, not on every streamed frame.
+  //
+  // The cache key contains the whole body, so while an agent streams a code
+  // block every appended character was a miss that also STORED an entry —
+  // re-tokenizing the growing block each frame and filling a 200-entry FIFO
+  // with throwaway partials, evicting genuinely reusable ones. A block that is
+  // already complete on mount settles immediately, so static content is
+  // unaffected.
+  const [settledCode, setSettledCode] = useState(trimmed);
+  useEffect(() => {
+    if (settledCode === trimmed) {
+      return;
+    }
+    const timer = setTimeout(
+      () => setSettledCode(trimmed),
+      HIGHLIGHT_SETTLE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [settledCode, trimmed]);
+
+  const cacheKey = `${theme}:${resolvedLanguage}:${settledCode}`;
   const [inView, setInView] = useState(() => highlightCache.has(cacheKey));
 
-  useEffect(() => {
-    const observer = new MutationObserver(() => setTheme(pickShikiTheme()));
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme", "class"],
-    });
-    return () => observer.disconnect();
-  }, []);
+  useEffect(() => subscribeShikiTheme(setTheme), []);
 
   useEffect(() => {
     if (inView) return;
@@ -182,7 +234,7 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
     let cancelled = false;
     void (async () => {
       try {
-        const html = await codeToHtml(trimmed, {
+        const html = await codeToHtml(settledCode, {
           lang: resolvedLanguage,
           theme,
         });
@@ -201,7 +253,7 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
     return () => {
       cancelled = true;
     };
-  }, [cacheKey, inView, resolvedLanguage, theme, trimmed]);
+  }, [cacheKey, inView, resolvedLanguage, settledCode, theme]);
 
   async function handleCopy() {
     try {
@@ -233,7 +285,11 @@ export function CodeBlock({ language, code }: CodeBlockProps) {
           {copied ? "Copied" : "Copy"}
         </button>
       </div>
-      {highlighted ? (
+      {/* Only show highlighted HTML when it corresponds to the text on screen.
+          While the body is still growing, settledCode lags `trimmed`, and
+          rendering the stale highlight would freeze a streaming block at an
+          earlier frame. The plain <pre> below stays live throughout. */}
+      {highlighted && settledCode === trimmed ? (
         <div
           className={`md-code-block-shiki ${expanded ? "" : "md-code-block-collapsed"}`.trim()}
           dangerouslySetInnerHTML={{ __html: highlighted }}

--- a/apps/desktop/src/components/marketplace/codeBlockHighlight.test.ts
+++ b/apps/desktop/src/components/marketplace/codeBlockHighlight.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(__dirname, "CodeBlock.tsx"), "utf8");
+
+/**
+ * STRUCTURAL guard. CodeBlock is a React component with a shiki dependency and
+ * DOM observers, and the repo has no React test renderer — so the behaviour
+ * (highlight once when the text settles, share one theme observer) is not
+ * reachable from a unit test here. These pin the three properties that made it
+ * expensive, each of which is a small edit away from coming back.
+ */
+
+test("highlighting is keyed on settled text, not the live body", () => {
+  // The cache key contains the whole body. Keyed on the live text, every
+  // streamed character was a miss that also stored an entry — re-tokenizing
+  // each frame and filling a 200-entry FIFO with throwaway partials.
+  assert.match(
+    source,
+    /const cacheKey = `\$\{theme\}:\$\{resolvedLanguage\}:\$\{settledCode\}`/,
+    "the highlight cache key is back on the live body",
+  );
+  assert.match(
+    source,
+    /await codeToHtml\(settledCode,/,
+    "highlighting no longer runs on the settled text",
+  );
+});
+
+test("a streaming block never renders a stale highlight", () => {
+  // settledCode lags `trimmed` while the body grows, so using the highlighted
+  // HTML unconditionally would freeze a streaming block at an earlier frame.
+  assert.match(
+    source,
+    /\{highlighted && settledCode === trimmed \? \(/,
+    "highlighted HTML is rendered without checking it matches the current text",
+  );
+});
+
+test("one theme observer is shared across code blocks", () => {
+  // A long conversation renders many CodeBlocks; each used to observe
+  // <html> itself for a signal that changes a handful of times per session.
+  assert.match(source, /function subscribeShikiTheme\(/);
+  assert.match(source, /useEffect\(\(\) => subscribeShikiTheme\(setTheme\), \[\]\)/);
+
+  const observers = source.match(/new MutationObserver\(/g) ?? [];
+  assert.equal(
+    observers.length,
+    1,
+    `expected exactly one MutationObserver construction, found ${observers.length}`,
+  );
+  // …and it must be released when the last block unmounts.
+  assert.match(source, /rootThemeObserver\?\.disconnect\(\)/);
+});

--- a/apps/desktop/src/components/marketplace/codeBlockHighlight.test.ts
+++ b/apps/desktop/src/components/marketplace/codeBlockHighlight.test.ts
@@ -32,11 +32,18 @@ test("highlighting is keyed on settled text, not the live body", () => {
 });
 
 test("a streaming block never renders a stale highlight", () => {
-  // settledCode lags `trimmed` while the body grows, so using the highlighted
-  // HTML unconditionally would freeze a streaming block at an earlier frame.
+  // Two distinct staleness sources, and checking only one leaves a visible
+  // flash:
+  //
+  //   settledCode === trimmed   — the body has stopped growing. Without it a
+  //                               streaming block freezes at an earlier frame.
+  //   highlighted.key === cacheKey — the HTML belongs to THIS text. Without it
+  //                               the commit in which settledCode catches up
+  //                               paints the previous, shorter body, because
+  //                               the clearing effect has not run yet.
   assert.match(
     source,
-    /\{highlighted && settledCode === trimmed \? \(/,
+    /highlighted\?\.key === cacheKey && settledCode === trimmed \? \(/,
     "highlighted HTML is rendered without checking it matches the current text",
   );
 });
@@ -55,4 +62,23 @@ test("one theme observer is shared across code blocks", () => {
   );
   // …and it must be released when the last block unmounts.
   assert.match(source, /rootThemeObserver\?\.disconnect\(\)/);
+});
+
+test("cached and freshly computed highlights both carry their key", () => {
+  // Storing bare HTML is what allowed a commit to paint the previous body's
+  // highlight, so both writers have to record the key it was produced for.
+  assert.match(
+    source,
+    /setHighlighted\(\{ key: cacheKey, html: cached \}\)/,
+    "the cache hit path stores HTML without its key",
+  );
+  assert.match(
+    source,
+    /setHighlighted\(\{ key: cacheKey, html \}\)/,
+    "the freshly highlighted path stores HTML without its key",
+  );
+  assert.match(
+    source,
+    /dangerouslySetInnerHTML=\{\{ __html: highlighted\.html \}\}/,
+  );
 });


### PR DESCRIPTION
## Summary

Two costs, both worst in exactly the case that matters — an agent writing code into the chat.

**1. The cache key contains the whole body.**

```ts
const cacheKey = `${theme}:${resolvedLanguage}:${trimmed}`;
```

So every appended character was a **miss that also stored an entry**. A 300-line file being written re-tokenized the growing block on each frame *and* filled the 200-entry FIFO with throwaway partials, evicting genuinely reusable ones on the way out.

Highlighting now runs on text that has stopped changing for 120ms. Streaming output changes far faster than that, so a block being written is tokenized **once at the end** instead of hundreds of times. A block already complete on mount settles immediately, so static content is unaffected.

**2. Every CodeBlock observed `<html>` for theme changes.** A long conversation renders many of them, each with its own `MutationObserver` on the root element, for a signal that changes a handful of times per session. There's now one observer for the app, released when the last block unmounts.

## The part I nearly got wrong

While the body is still growing, `settledCode` lags `trimmed` — so rendering the highlighted HTML unconditionally would have **frozen a streaming block at an earlier frame**. I caught it reading the render path after writing the debounce, not before.

The highlight is now used only when it matches the text on screen; the plain `<pre>` stays live throughout, which is what the user saw during streaming anyway (every frame was a cache miss, so `highlighted` was null or one frame stale). There's a dedicated guard test for this, because it's the failure mode a future edit is most likely to reintroduce.

## On the tests

Structural, and labelled as such — `CodeBlock` is a React component with a shiki dependency and DOM observers, and the repo has no React test renderer. They pin the three properties that made it expensive.

**All three mutation-verified**, each failing exactly one test:

| Mutation | |
|---|---|
| re-key the cache on the live body | fails |
| drop the stale-highlight check | fails |
| restore a per-instance observer | fails |

## Validation

- [x] `npm run desktop:typecheck` — clean
- [x] `bun run test:electron` — 119/119
- [x] `src/**/*.test.{ts,tsx}` — 187/189; the 2 failures are the `turnResultCards` pair fixed in #487
- [ ] Not measured, and not watched live. I have no before/after tokenization counts, and I haven't observed a streaming code block in the running app — which is the one thing that would confirm the stale-highlight guard behaves as intended. Worth a look before merge if you want certainty on that.

## Docs

- [ ] n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)