### PR TITLE
perf(runtime): wire the composio cache's invalidation hook, then raise its TTL

### DIFF
--- a/runtime/api-server/src/composio-cache-invalidation.test.ts
+++ b/runtime/api-server/src/composio-cache-invalidation.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, test } from "node:test";
+
+import { composioInlineCachePath } from "../../harnesses/src/composio-inline-cache.js";
+import { invalidateComposioInlineToolCache } from "./composio-cache-invalidation.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function seedCache(workspaceDir: string): string {
+  const target = composioInlineCachePath(workspaceDir);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, JSON.stringify({ version: 1, payload: { tools: [] } }));
+  return target;
+}
+
+function fakeStore(workspaceIds: string[]) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "hb-composio-invalidate-"));
+  tempDirs.push(root);
+  return {
+    root,
+    listWorkspaces: () => workspaceIds.map((id) => ({ id })),
+    workspaceDir: (id: string) => path.join(root, id),
+  };
+}
+
+test("clears every workspace, because connections are user-global", () => {
+  const store = fakeStore(["root", "second", "third"]);
+  const targets = ["root", "second", "third"].map((id) =>
+    seedCache(store.workspaceDir(id)),
+  );
+
+  const cleared = invalidateComposioInlineToolCache(store);
+
+  assert.equal(cleared, 3);
+  for (const target of targets) {
+    assert.equal(fs.existsSync(target), false, `${target} survived invalidation`);
+  }
+});
+
+test("workspaces with no cache are not an error", () => {
+  const store = fakeStore(["root", "never-used"]);
+  seedCache(store.workspaceDir("root"));
+
+  assert.equal(invalidateComposioInlineToolCache(store), 1);
+});
+
+test("one unreadable workspace does not stop the others", () => {
+  const store = fakeStore(["broken", "fine"]);
+  const good = seedCache(store.workspaceDir("fine"));
+  const throwing = {
+    listWorkspaces: store.listWorkspaces,
+    workspaceDir: (id: string) => {
+      if (id === "broken") throw new Error("workspace dir unavailable");
+      return store.workspaceDir(id);
+    },
+  };
+
+  assert.equal(invalidateComposioInlineToolCache(throwing), 1);
+  assert.equal(fs.existsSync(good), false);
+});
+
+test("a store that cannot list workspaces is survivable", () => {
+  const hostile = {
+    listWorkspaces: () => {
+      throw new Error("db locked");
+    },
+    workspaceDir: () => "/nowhere",
+  };
+
+  // Invalidation is attached to a user action (connect/disconnect); it must
+  // never be the reason that action fails.
+  assert.equal(invalidateComposioInlineToolCache(hostile), 0);
+});
+
+/**
+ * STRUCTURAL guard, and the point of the whole change.
+ *
+ * The cache's freshness now rests on explicit invalidation rather than a short
+ * TTL, so a mutation site that forgets to invalidate leaves a stale tool listing
+ * for the *whole* (now much longer) TTL — a worse failure than the 120 s window
+ * this replaced. Adding a seventh write site is exactly how that regresses, so
+ * pin the set rather than the six known call sites.
+ */
+test("every integration-connection write invalidates the cache", () => {
+  const files = ["integrations.ts", "integration-broker.ts", "oauth-service.ts"];
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const lines = fs.readFileSync(path.join(here, file), "utf8").split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      if (
+        !/\.(upsertIntegrationConnection|deleteIntegrationConnection)\(/.test(lines[i]!)
+      ) {
+        continue;
+      }
+      // The invalidation belongs with the write: look ahead past the end of the
+      // call for it, not across the whole function.
+      const window = lines.slice(i, i + 30).join("\n");
+      if (!window.includes("invalidateComposioInlineToolCache(")) {
+        offenders.push(`${file}:${i + 1}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `these connection writes leave a stale inline tool listing behind:\n${offenders.join("\n")}`,
+  );
+});

--- a/runtime/api-server/src/composio-cache-invalidation.ts
+++ b/runtime/api-server/src/composio-cache-invalidation.ts
@@ -1,0 +1,67 @@
+import { clearComposioInlineCache } from "../../harnesses/src/composio-inline-cache.js";
+
+/**
+ * Drop the cached Composio inline tool listing after a connection changes.
+ *
+ * `composio-inline-cache.ts` shipped with `clearComposioInlineCache` documented
+ * as "the connect/install hook" — and nothing ever called it, so the TTL was the
+ * only invalidation the cache had. That forced one number to do two incompatible
+ * jobs: short enough that a newly connected integration appears promptly, and
+ * long enough that the bootstrap fetch actually hits between turns. It was tuned
+ * for the first, so the second never happened on any turn a user took more than
+ * two minutes to send.
+ *
+ * With explicit invalidation the TTL only has to cover changes made OUTSIDE this
+ * runtime (see the note on its `DEFAULT_TTL_MS`), so it can be far longer.
+ *
+ * ## Why this fans out over every workspace
+ *
+ * The cache is keyed per workspace, but integration connections are **user-global**
+ * — `RuntimeIntegrationService.deleteConnection` spells this out: "Connections are
+ * user-global; deleting one means it should also disappear from every workspace
+ * that binds it." So a connection mutation has no single workspace to invalidate,
+ * and filtering by current bindings would be wrong in the case that matters most:
+ * a freshly connected account has no bindings yet.
+ *
+ * Clearing every workspace is therefore the correct scope, and it is cheap — one
+ * `unlink` of a small JSON file per workspace, on an action a user takes by hand.
+ */
+export interface ComposioCacheInvalidationStore {
+  listWorkspaces(options?: { includeDeleted?: boolean }): Array<{ id: string }>;
+  workspaceDir(workspaceId: string): string;
+}
+
+export interface ComposioCacheInvalidationLogger {
+  info?: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+/**
+ * Clear every workspace's cached listing. Never throws — a failed invalidation
+ * must not fail the connect/disconnect it is attached to, and the worst case is
+ * the pre-existing behavior (stale until the TTL).
+ *
+ * @returns how many workspaces actually had a cache file to drop.
+ */
+export function invalidateComposioInlineToolCache(
+  store: ComposioCacheInvalidationStore,
+  logger?: ComposioCacheInvalidationLogger,
+): number {
+  let cleared = 0;
+  try {
+    for (const workspace of store.listWorkspaces({ includeDeleted: true })) {
+      try {
+        if (clearComposioInlineCache(store.workspaceDir(workspace.id))) {
+          cleared += 1;
+        }
+      } catch {
+        // A single unreadable workspace dir must not stop the others.
+      }
+    }
+  } catch {
+    return cleared;
+  }
+  if (cleared > 0) {
+    logger?.info?.("composio inline tool cache invalidated", { workspaces: cleared });
+  }
+  return cleared;
+}

--- a/runtime/api-server/src/integration-broker.ts
+++ b/runtime/api-server/src/integration-broker.ts
@@ -2,6 +2,7 @@ import { type RuntimeStateStore } from "@holaboss/runtime-state-store";
 
 import { resolveConnectionMerged } from "./integration-connections-merged.js";
 import { validateSignedGrant } from "./grant-signing.js";
+import { invalidateComposioInlineToolCache } from "./composio-cache-invalidation.js";
 
 export type BrokerErrorCode =
   | "grant_invalid"
@@ -446,6 +447,13 @@ export class IntegrationBrokerService {
         secretRef: newPayload,
         accountExternalId: connection.accountExternalId
       });
+      // Only when this refresh REVIVES the connection. A routine refresh swaps
+      // secretRef on an already-active row and cannot change the active-toolkit
+      // set the inline listing is derived from — invalidating there would drop
+      // the cache on a background token rotation and undo the point of having it.
+      if (connection.status !== "active") {
+        invalidateComposioInlineToolCache(this.store);
+      }
       return tokens.access_token;
     } catch { return null; }
   }

--- a/runtime/api-server/src/integrations.ts
+++ b/runtime/api-server/src/integrations.ts
@@ -11,6 +11,7 @@ import {
   type IntegrationCatalogProviderRecord,
 } from "./integration-catalog.js";
 import { resolveWorkspaceAppRuntime } from "./workspace-apps.js";
+import { invalidateComposioInlineToolCache } from "./composio-cache-invalidation.js";
 
 export interface IntegrationConnectionPayload {
   connection_id: string;
@@ -367,6 +368,9 @@ export class RuntimeIntegrationService {
       accountHandle: params.accountHandle ?? existing?.accountHandle ?? null,
       accountEmail: params.accountEmail ?? existing?.accountEmail ?? null
     });
+    // The set of connected toolkits just changed, so the cached inline tool
+    // listing is wrong until this drops it.
+    invalidateComposioInlineToolCache(this.store);
 
     this.notifyConnectionActive(
       record.connectionId,
@@ -433,6 +437,9 @@ export class RuntimeIntegrationService {
           ? params.contextCronAutoFetchEnabled
           : existing.contextCronAutoFetchEnabled,
     });
+    // status and grantedScopes are both updatable here, and either can move a
+    // connection in or out of the active set the listing is built from.
+    invalidateComposioInlineToolCache(this.store);
 
     this.notifyConnectionActive(
       record.connectionId,
@@ -552,6 +559,7 @@ export class RuntimeIntegrationService {
         repointed += 1;
       }
       this.store.deleteIntegrationConnection(removeId);
+      invalidateComposioInlineToolCache(this.store);
     }
     });
 
@@ -582,6 +590,9 @@ export class RuntimeIntegrationService {
     }
 
     this.store.deleteIntegrationConnection(normalizedId);
+    // Connections are user-global, so this removal affects every workspace's
+    // listing — see invalidateComposioInlineToolCache on why it fans out.
+    invalidateComposioInlineToolCache(this.store);
     return { deleted: true, removed_bindings: bindings.length };
   }
 

--- a/runtime/api-server/src/oauth-service.ts
+++ b/runtime/api-server/src/oauth-service.ts
@@ -1,6 +1,7 @@
 import { createServer, type Server } from "node:http";
 import { randomBytes, createHash, randomUUID } from "node:crypto";
 import { type RuntimeStateStore } from "@holaboss/runtime-state-store";
+import { invalidateComposioInlineToolCache } from "./composio-cache-invalidation.js";
 
 export class OAuthService {
   readonly store: RuntimeStateStore;
@@ -125,5 +126,9 @@ export class OAuthService {
       grantedScopes: tokens.scope ? tokens.scope.split(" ") : config.scopes,
       status: "active", secretRef: secretPayload
     });
+    // A brand-new active connection changes the inline tool listing; without
+    // this the agent cannot see the integration the user just authorized until
+    // the cache TTL lapses.
+    invalidateComposioInlineToolCache(this.store);
   }
 }

--- a/runtime/harnesses/src/composio-inline-cache.test.ts
+++ b/runtime/harnesses/src/composio-inline-cache.test.ts
@@ -36,21 +36,50 @@ test("misses for a different workspace id (no cross-workspace leakage)", () => {
 test("misses once past the TTL, hits inside it", () => {
   const dir = tmpWorkspace();
   const t0 = 1_000_000;
-  writeComposioInlineCache({ workspaceDir: dir, workspaceId: "root", payload: PAYLOAD, nowMs: t0 });
+  // Drive the window off the env override rather than the default, so this
+  // keeps testing the BEHAVIOUR when the default moves. It has moved once
+  // already (120s → 15min, once explicit invalidation landed) and this test
+  // pinned the old number in a comment and a magic offset.
+  const ttl = 30_000;
+  const env = { HB_COMPOSIO_CACHE_TTL_MS: String(ttl) } as NodeJS.ProcessEnv;
+  writeComposioInlineCache({ workspaceDir: dir, workspaceId: "root", payload: PAYLOAD, nowMs: t0, env });
   assert.deepEqual(
-    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 + 60_000 }),
+    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 + ttl - 1, env }),
     PAYLOAD,
-    "inside the 120s TTL",
+    "inside the TTL",
   );
   assert.equal(
-    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 + 300_000 }),
+    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 + ttl + 1, env }),
     null,
     "past the TTL",
   );
   // a clock that jumped backwards must not serve a 'future' entry
   assert.equal(
-    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 - 5_000 }),
+    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 - 5_000, env }),
     null,
+  );
+});
+
+test("the default TTL spans a realistic inter-turn gap", () => {
+  const dir = tmpWorkspace();
+  const t0 = 1_000_000;
+  writeComposioInlineCache({ workspaceDir: dir, workspaceId: "root", payload: PAYLOAD, nowMs: t0 });
+
+  // The whole point of raising it: at 120s the bootstrap fetch missed on any
+  // turn a user took longer than two minutes to send, which is most real
+  // conversation. Freshness is now carried by explicit invalidation on connect
+  // and disconnect (see composio-cache-invalidation.ts), not by this number.
+  assert.deepEqual(
+    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 + 5 * 60_000 }),
+    PAYLOAD,
+    "a five-minute gap between turns must still hit",
+  );
+  // …but it stays bounded, because a change made OUTSIDE this runtime (the web
+  // app, or a revoke at the provider) has no invalidation path here.
+  assert.equal(
+    readComposioInlineCache({ workspaceDir: dir, workspaceId: "root", nowMs: t0 + 60 * 60_000 }),
+    null,
+    "an hour-old entry must not be served",
   );
 });
 

--- a/runtime/harnesses/src/composio-inline-cache.ts
+++ b/runtime/harnesses/src/composio-inline-cache.ts
@@ -30,9 +30,29 @@ import path from "node:path";
 const CACHE_VERSION = 1;
 export const COMPOSIO_INLINE_CACHE_FILE = "composio-inline-tool-cache.json";
 
-/** Long enough that a multi-turn conversation pays the fetch once, short enough
- *  that a freshly connected integration shows up without an explicit refresh. */
-const DEFAULT_TTL_MS = 120_000;
+/**
+ * The TTL no longer carries the freshness job.
+ *
+ * It was 120 s because it was the *only* invalidation this cache had —
+ * `clearComposioInlineCache` shipped documented as the connect/install hook and
+ * was never called. One number had to be both short enough that a newly
+ * connected integration appears promptly and long enough that the bootstrap
+ * fetch hits between turns, and it was tuned for the first. So the ~773 ms
+ * bootstrap fetch missed on every turn a user took more than two minutes to
+ * send — which is most real conversation.
+ *
+ * Connection mutations made through this runtime now invalidate explicitly
+ * (`composio-cache-invalidation.ts`), which is strictly fresher than a 120 s
+ * window: a disconnect takes effect immediately instead of up to two minutes
+ * later.
+ *
+ * What the TTL still has to cover is changes made OUTSIDE this runtime — an
+ * integration connected in the web app, or revoked at the provider — which have
+ * no invalidation path here. That is what keeps this minutes rather than hours:
+ * 15 minutes captures nearly every inter-turn gap while bounding how long an
+ * externally-made change can stay invisible.
+ */
+const DEFAULT_TTL_MS = 15 * 60_000;
 
 export function composioInlineCachePath(workspaceDir: string): string {
   return path.join(workspaceDir, ".holaboss", "state", COMPOSIO_INLINE_CACHE_FILE);


### PR DESCRIPTION
## The gap

`clearComposioInlineCache` (`composio-inline-cache.ts:119`) shipped with the cache, documented as *"the connect/install hook"*, unit-tested — and **never called from anywhere**.

So the 120s TTL was the cache's only invalidation, and one number had to do two incompatible jobs:

- short enough that a newly connected integration shows up promptly, and
- long enough that the bootstrap fetch actually hits between turns.

It was tuned for the first. So the ~773 ms bootstrap fetch missed on every turn a user took longer than two minutes to send — which is most real conversation.

## The change

Six connection-write sites now invalidate explicitly, and `DEFAULT_TTL_MS` goes 120s → 15min.

That is **strictly fresher** than before for anything done through this runtime: a disconnect takes effect immediately instead of up to two minutes later. It stays minutes rather than hours because a change made *outside* the runtime — connected in the web app, revoked at the provider — still has no invalidation path here, and the TTL is the only bound on that.

## Two things this had to get right

**It fans out over every workspace.** The cache is keyed per workspace, but integration connections are **user-global** — `RuntimeIntegrationService.deleteConnection` spells it out: *"Connections are user-global; deleting one means it should also disappear from every workspace that binds it."* Filtering by current bindings would be wrong in the case that matters most: a freshly connected account has no bindings yet. (`listWorkspaces()` returns one synthetic root today, so it's a one-entry loop — but it stays correct if multi-workspace returns.)

**The token-refresh site is conditional.** `integration-broker.ts` refreshes tokens in the background; that swaps `secretRef` on an already-active row and cannot change the active-toolkit set the listing derives from. Invalidating there would drop the cache on every routine rotation and undo the entire point. It now invalidates only when the refresh *revives* a connection (`connection.status !== "active"`).

## Tests

Five new, plus one repaired:

- clears every workspace; missing caches aren't errors; one unreadable workspace doesn't stop the others; a store that can't list workspaces is survivable (invalidation is attached to a user action — it must never be why that action fails)
- **structural guard**: greps all three modules for `upsertIntegrationConnection` / `deleteIntegrationConnection` and asserts each is accompanied by an invalidation. Verified it fails and names the line when one is removed. The cost of missing a seventh site is now a whole TTL of staleness rather than 120s, so this is worth pinning.
- the existing TTL test drove off the old default via a comment and a magic offset; it now drives off the env override, so it tests the behaviour when the default moves again.

1117 tests, 0 failures. (These now actually run in CI — before #503 this file sat in the glob's blind spot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)