### PR TITLE
fix(runtime): stop the boot integrity check from bricking the app forever

### DIFF
--- a/runtime/state-store/src/store.test.ts
+++ b/runtime/state-store/src/store.test.ts
@@ -5254,3 +5254,131 @@ test("searchOutputs indexes title/body and honors producer + date filters", () =
 
   store.close();
 });
+
+test("an integrity check that was killed mid-run is not retried on the next boot", () => {
+  // The livelock this guards: quick_check is unbounded (it walks every page —
+  // ~80s on a 2GB data.db) while the desktop gives the runtime ~30s to answer
+  // /healthz before killing and respawning it. The kill leaves the dirty marker,
+  // which re-arms the check, which is killed again. The app never starts and
+  // nothing logs an error. Observed in the field on a 1.9GB data.db that was in
+  // fact healthy — quick_check returned "ok" when run to completion by hand.
+  const root = makeTempDir("hb-state-store-check-livelock-");
+  const opts = {
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  };
+
+  const store1 = new RuntimeStateStore(opts);
+  store1.enqueueInput({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    payload: { text: "hello" },
+    idempotencyKey: "idem-1",
+  });
+  const dataDbPath = store1.rootRuntimeDbPath;
+  const markerPath = `${dataDbPath}.open`;
+  store1.close();
+
+  // The DB is intact — as it was in the field. Only the marker says a previous
+  // boot died while checking.
+  fs.writeFileSync(markerPath, "checking");
+
+  // A small healthy DB passes quick_check in milliseconds, so behaviour alone
+  // cannot distinguish "skipped" from "ran and passed" — and the bug is that it
+  // RUNS. Observe which path was taken.
+  const warnings: string[] = [];
+  const realWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  let store2: RuntimeStateStore;
+  let recovered: ReturnType<RuntimeStateStore["enqueueInput"]>;
+  try {
+    store2 = new RuntimeStateStore(opts);
+    recovered = store2.enqueueInput({
+      workspaceId: "workspace-1",
+      sessionId: "session-main",
+      payload: { text: "after skipped check" },
+      idempotencyKey: "idem-2",
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.ok(
+    warnings.some((line) => line.includes("skipping the integrity check")),
+    `expected the check to be skipped after a killed run, saw: ${JSON.stringify(warnings)}`,
+  );
+  assert.ok(
+    !warnings.some((line) => line.includes("verifying")),
+    "the check was re-run after having been killed once — that is the livelock",
+  );
+  assert.ok(recovered?.inputId, "the store boots instead of looping on the check");
+  assert.equal(
+    fs.readFileSync(markerPath, "utf8"),
+    "open",
+    "the marker resets to the open state so a later crash re-arms the check",
+  );
+  // Nothing was quarantined: a healthy DB must not be thrown away just because
+  // the check could not be completed in time.
+  assert.deepEqual(
+    fs.readdirSync(path.dirname(dataDbPath)).filter((f) => f.startsWith("data.db.corrupt-")),
+    [],
+    "a healthy DB must survive a skipped check",
+  );
+  store2.close();
+
+  // And the data is still there — this is the whole point of not resetting.
+  const store3 = new RuntimeStateStore(opts);
+  for (const key of ["idem-1", "idem-2"]) {
+    assert.ok(
+      store3.getInputByIdempotencyKey({ workspaceId: "workspace-1", idempotencyKey: key }),
+      `${key} survived the skipped check`,
+    );
+  }
+  store3.close();
+});
+
+test("a legacy empty marker still triggers the integrity check", () => {
+  // Markers written before the marker carried a state are empty strings. They
+  // must keep meaning "crashed while open", or an upgrade would silently drop
+  // the corruption guard for every user mid-crash.
+  const root = makeTempDir("hb-state-store-legacy-marker-");
+  const opts = {
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  };
+  const store1 = new RuntimeStateStore(opts);
+  store1.enqueueInput({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    payload: { text: "hello" },
+    idempotencyKey: "idem-1",
+  });
+  const dataDbPath = store1.rootRuntimeDbPath;
+  store1.close();
+
+  for (const suffix of ["-wal", "-shm"]) {
+    fs.rmSync(`${dataDbPath}${suffix}`, { force: true });
+  }
+  const size = fs.statSync(dataDbPath).size;
+  const fd = fs.openSync(dataDbPath, "r+");
+  try {
+    fs.writeSync(fd, Buffer.alloc(size - 4096, 0xff), 0, size - 4096, 4096);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.writeFileSync(`${dataDbPath}.open`, ""); // legacy format
+
+  const store2 = new RuntimeStateStore(opts);
+  store2.enqueueInput({
+    workspaceId: "workspace-1",
+    sessionId: "session-main",
+    payload: { text: "after reset" },
+    idempotencyKey: "idem-2",
+  });
+  const quarantined = fs
+    .readdirSync(path.dirname(dataDbPath))
+    .filter((f) => f.startsWith("data.db.corrupt-"));
+  assert.equal(quarantined.length, 1, "a legacy marker must still run the check");
+  store2.close();
+});

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -1134,6 +1134,15 @@ export const DEFAULT_OUTPUT_EVENT_RETENTION: OutputEventRetentionPolicy = {
 };
 
 /**
+ * States for the `data.db.open` marker. The distinction exists because the
+ * boot-time integrity check is unbounded and the desktop's startup probe is not:
+ * without a way to tell "died while open" from "died while checking", a check
+ * that outlives the probe re-arms itself on every boot and never completes.
+ */
+const ROOT_DB_MARKER_OPEN = "open";
+const ROOT_DB_MARKER_CHECKING = "checking";
+
+/**
  * Cap on how many over-the-limit events the WRITE path trims per run completion,
  * so a first-time trim of a huge legacy session can't block the hot path with a
  * 300k-row DELETE. The background sweep clears any remaining backlog.
@@ -13838,9 +13847,31 @@ export class RuntimeStateStore {
    * Its presence at open time means the previous run crashed — the only way a
    * SQLite DB can be left inconsistent — and thus the only time the integrity
    * check below is worth its cost. A clean launch never pays for it.
+   *
+   * Its CONTENTS distinguish how far the previous run got:
+   *   "open"     — the DB was open for normal use when the process died.
+   *   "checking" — the process died while running the integrity check itself.
+   *
+   * That distinction is load-bearing; see {@link ROOT_DB_MARKER_CHECKING}.
    */
   private rootDbDirtyMarkerPath(): string {
     return `${this.rootRuntimeDbPath}.open`;
+  }
+
+  private readRootDbMarker(): string | null {
+    try {
+      return fs.readFileSync(this.rootDbDirtyMarkerPath(), "utf8").trim();
+    } catch {
+      return null;
+    }
+  }
+
+  private writeRootDbMarker(state: string): void {
+    try {
+      fs.writeFileSync(this.rootDbDirtyMarkerPath(), state);
+    } catch {
+      // best-effort — a missing marker only costs an extra check next crash.
+    }
   }
 
   private openRootDbConnectionOnly(): Database.Database {
@@ -13920,19 +13951,41 @@ export class RuntimeStateStore {
    * cause. Gated on an unclean prior shutdown so healthy launches stay fast.
    */
   private openRootRuntimeDbConnection(): Database.Database {
-    const markerPath = this.rootDbDirtyMarkerPath();
-    const priorRunUnclean = fileExists(markerPath);
+    const priorMarker = this.readRootDbMarker();
+    const priorRunUnclean = priorMarker !== null;
+    // The previous run died DURING the check itself. Running it again would die
+    // the same way, forever: quick_check is unbounded (it walks every page — ~80s
+    // on a 2GB data.db) and the desktop gives the runtime ~30s to answer /healthz
+    // before killing and respawning it. Being killed leaves the marker, which
+    // re-arms the check. That livelock bricks the app with no error anywhere:
+    // the runtime never binds and the log only shows the boot line repeating.
+    //
+    // So the check gets exactly ONE attempt. If it did not survive that, boot
+    // without it and say so — a DB that is genuinely malformed still surfaces at
+    // migration time, which fails loudly, whereas the loop never surfaces at all.
+    const integrityCheckDiedLastBoot = priorMarker === ROOT_DB_MARKER_CHECKING;
     let db: Database.Database | null = null;
-    if (priorRunUnclean) {
+    if (priorRunUnclean && !integrityCheckDiedLastBoot) {
+      // Record that the check is underway BEFORE running it, so that if this
+      // process is killed mid-check the next boot can tell "crashed while open"
+      // from "crashed while checking".
+      this.writeRootDbMarker(ROOT_DB_MARKER_CHECKING);
+      console.warn(
+        `[state-store] previous run exited uncleanly — verifying ${path.basename(this.rootRuntimeDbPath)} integrity (this can take minutes on a large database)`,
+      );
       // The prior run crashed, so the DB may be malformed. Corruption can surface
       // either as a throw while opening/setting pragmas OR as a non-"ok"
       // quick_check — treat both the same: quarantine the bad file and start
       // fresh so a corrupt DB can't wedge migrations or the queue worker.
+      const startedAt = Date.now();
       try {
         db = this.openRootDbConnectionOnly();
         if (!this.rootDbPassesIntegrityCheck(db)) {
           throw new Error("root data.db failed quick_check");
         }
+        console.warn(
+          `[state-store] integrity check passed in ${Math.round((Date.now() - startedAt) / 1000)}s`,
+        );
       } catch {
         try {
           db?.close();
@@ -13942,16 +13995,16 @@ export class RuntimeStateStore {
         db = null;
         this.quarantineCorruptRootDb();
       }
+    } else if (integrityCheckDiedLastBoot) {
+      console.warn(
+        `[state-store] skipping the integrity check on ${path.basename(this.rootRuntimeDbPath)}: the previous boot was killed while running it. Booting without it — run "PRAGMA quick_check" by hand if you suspect corruption.`,
+      );
     }
     if (!db) {
       db = this.openRootDbConnectionOnly();
     }
     // Mark the session open; close() clears it on a clean exit.
-    try {
-      fs.writeFileSync(markerPath, "");
-    } catch {
-      // best-effort — a missing marker only costs an extra check next crash.
-    }
+    this.writeRootDbMarker(ROOT_DB_MARKER_OPEN);
     return db;
   }
 


### PR DESCRIPTION
Found on a real install (2026.809.1): holaOS would not start. The runtime respawned every ~33s, never bound its port, and logged nothing but its own boot line.

Sampling the hung process gave the cause immediately:

```
sqlite3_step → sqlite3VdbeExec → checkTreePage → readDbPage → unixRead
```

`PRAGMA quick_check`, walking a **1.9 GB** `data.db` at module load, before the server can bind.

## The loop

1. A previous run exits uncleanly, leaving the `data.db.open` marker.
2. Boot sees the marker and starts `quick_check`. It is **unbounded** — **80s** measured on that file, warm cache, idle machine.
3. The desktop allows 30 attempts × 1s for `/healthz` (`DEFAULT_RUNTIME_STARTUP_HEALTH_ATTEMPTS`, `main.ts:4482`) and kills the runtime.
4. Being killed is itself an unclean exit, so the marker survives — and step 2 runs again. **Forever.**

The guard against an unclean shutdown had become the cause of one, and it did it silently.

**The database was fine.** `quick_check` returned `ok` when finally run to completion by hand.

## The fix

The marker now records *which phase* died — `"open"` vs `"checking"` — so the check gets exactly **one** attempt. If it didn't survive that, boot without it and say so.

That's a deliberate trade: a genuinely malformed DB still surfaces, loudly, at first use (`SQLITE_CORRUPT`), whereas the loop surfaced nowhere at all. An empty marker — the pre-upgrade format — still means "crashed while open", so the guard isn't silently dropped for anyone mid-crash.

Both paths now log. The absence of any log line is why this needed a process sample to diagnose rather than a glance at `runtime.log`.

## Tests

- **the livelock guard** — healthy DB + `"checking"` marker must boot without re-running the check. A small DB passes `quick_check` in milliseconds, so behaviour alone can't distinguish "skipped" from "ran and passed" — and the bug is that it *runs*. The test captures `console.warn` to assert which path was taken. **Mutation-verified**: it passes with the fix reverted until it observes the path, then fails.
- **legacy marker** — an empty marker still triggers the check, so upgrades don't lose the guard.
- the pre-existing quarantine test is unchanged and still passes.

146 state-store tests green; 1117 api-server tests green.

## Not done here

The desktop already carries a 15-minute budget for slow starts (`MIGRATION_RUNTIME_STARTUP_HEALTH_ATTEMPTS = 900`) but only applies it to migrations. Reporting the integrity check as a startup phase so it inherits that budget is the better long-term fix.

Also unaddressed: retention has no *global* bound. On the affected install, 162 scheduled sessions each sat at exactly the 25,000-event cap — 2.29M rows, ~1.85 GB, all within policy and nothing prunable. The per-session cap can't stop N sessions summing to gigabytes, and boot cost scales with the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)