### PR TITLE
fix(runtime): start workers off the bind path, and publish a boot phase

### DIFF
--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -12999,6 +12999,8 @@ test("runtime api server starts and closes the recall embedding backfill worker"
   });
 
   await app.ready();
+  // Workers start in the background now, off the bind path.
+  await app.runtimeBootComplete();
   assert.equal(started, 1);
   assert.equal(woke, 0);
 
@@ -13085,6 +13087,8 @@ test("runtime api server starts and closes the main-session event worker", async
   });
 
   await app.ready();
+  // Workers start in the background now, off the bind path.
+  await app.runtimeBootComplete();
 
   assert.equal(started, 1);
   assert.equal(woke, 0);
@@ -14362,6 +14366,72 @@ test("POST /apps/install-archive serializes concurrent archive_url installs", as
       process.env.HOLABOSS_APP_ARCHIVE_URL_ALLOWLIST = savedEnv;
     }
     await app.close();
+    store.close();
+  }
+});
+
+test("the port binds without waiting for the background workers", async () => {
+  // The livelock this guards: everything awaited in onReady runs BEFORE
+  // app.listen() resolves, so a slow start delays the bind — and a runtime that
+  // has not bound is indistinguishable from a dead one to the desktop's health
+  // probe, which kills and respawns it. A 1.9GB install bricked exactly this
+  // way. The app auto-start had already been moved off this path for the same
+  // reason; the seven worker starts had not.
+  const root = makeTempDir("hb-runtime-api-boot-phase-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const app = buildTestRuntimeApiServer({ store });
+  try {
+    await app.ready();
+    // /runtime/boot-status must answer as soon as the server is up, whatever the
+    // workers are doing — that is the whole point of publishing a phase.
+    const response = await app.inject({ method: "GET", url: "/runtime/boot-status" });
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      ready: boolean;
+      phase: string;
+      phase_elapsed_ms: number;
+      total_elapsed_ms: number;
+    };
+    assert.equal(typeof body.phase, "string");
+    assert.ok(body.phase.length > 0, "a phase is always named");
+    assert.equal(typeof body.ready, "boolean");
+    assert.ok(Number.isFinite(body.phase_elapsed_ms));
+    assert.ok(Number.isFinite(body.total_elapsed_ms));
+  } finally {
+    await app.close();
+    store.close();
+  }
+});
+
+test("boot-status is reachable without auth, like the other boot probes", async () => {
+  // The desktop polls this before the app shell — and therefore any auth header
+  // — exists. If it required auth the splash could never read it, which is the
+  // situation that left users staring at a bare spinner.
+  const root = makeTempDir("hb-runtime-api-boot-status-auth-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const previousToken = process.env.SANDBOX_RUNTIME_API_TOKEN;
+  process.env.SANDBOX_RUNTIME_API_TOKEN = "secret-token";
+  let app: ReturnType<typeof buildTestRuntimeApiServer>;
+  try {
+    app = buildTestRuntimeApiServer({ store });
+    await app.ready();
+    for (const url of ["/healthz", "/runtime/boot-status", "/runtime/db-maintenance-status"]) {
+      const response = await app.inject({ method: "GET", url });
+      assert.equal(response.statusCode, 200, `${url} must not require auth`);
+    }
+  } finally {
+    if (previousToken === undefined) {
+      delete process.env.SANDBOX_RUNTIME_API_TOKEN;
+    } else {
+      process.env.SANDBOX_RUNTIME_API_TOKEN = previousToken;
+    }
+    await app!.close();
     store.close();
   }
 });

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -2980,6 +2980,17 @@ async function cleanupOrphanAppProcesses(
   }
 }
 
+declare module "fastify" {
+  interface FastifyInstance {
+    /**
+     * Resolves when the background boot sequence (workers, health monitor) has
+     * finished. `ready()` only covers the point at which the port binds — the
+     * workers deliberately start after it so a slow one cannot delay the bind.
+     */
+    runtimeBootComplete: () => Promise<void>;
+  }
+}
+
 export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}): FastifyInstance {
   const ownsStore = !options.store;
   const store =
@@ -3037,6 +3048,7 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     const AUTH_EXEMPT_PATHS = new Set<string>([
       "/healthz",
       "/runtime/db-maintenance-status",
+      "/runtime/boot-status",
     ]);
     const expectedHeader = `Bearer ${runtimeApiAuthToken}`;
     app.addHook("onRequest", async (request, reply) => {
@@ -3997,6 +4009,40 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   let dbMaintenanceProgress: DbMaintenanceProgress = IDLE_DB_MAINTENANCE_PROGRESS;
 
   /**
+   * Boot phase, published over /runtime/boot-status.
+   *
+   * A boot that takes a while is not a boot that has failed, but for a user
+   * those are the same picture: a spinner. The desktop had exactly one phase it
+   * could see (the retention sweep) and rendered a bare splash for everything
+   * else — so a runtime doing 80s of honest work looked identical to a wedged
+   * one, and the supervisor treated it as wedged.
+   *
+   * Every phase that can plausibly exceed a second reports here, so the splash
+   * can say what it is waiting for and the supervisor can tell "working" from
+   * "hung" by whether the phase advances.
+   */
+  const bootStartedAtMs = Date.now();
+  let bootCompletePromise: Promise<void> = Promise.resolve();
+  let bootPhase = "starting";
+  let bootPhaseStartedAtMs = bootStartedAtMs;
+  let bootReady = false;
+  const bootPhaseHistory: Array<{ phase: string; ms: number }> = [];
+  const enterBootPhase = (phase: string): void => {
+    const now = Date.now();
+    const previous = bootPhase;
+    const elapsed = now - bootPhaseStartedAtMs;
+    // Timings for every phase, so a slow boot is diagnosable from the log alone
+    // rather than needing a process sample.
+    bootPhaseHistory.push({ phase: previous, ms: elapsed });
+    app.log.info(
+      { phase: previous, ms: elapsed, next: phase },
+      `runtime boot: ${previous} took ${elapsed}ms`,
+    );
+    bootPhase = phase;
+    bootPhaseStartedAtMs = now;
+  };
+
+  /**
    * Ensures this app's MCP tools are registered in workspace.yaml's
    * `mcp_registry`. Runs idempotently after every app start so apps
    * installed via legacy paths or stale templates get auto-healed.
@@ -4711,16 +4757,57 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   });
 
   app.addHook("onReady", async () => {
-    await terminalSessionManager?.start();
-    await durableMemoryWorker?.start();
-    await queueWorker?.start();
-    await cronWorker?.start();
-    await mainSessionEventWorker?.start();
-    await recallEmbeddingBackfillWorker?.start();
-    await channelGatewayManager.start();
-    if (options.enableAppHealthMonitor !== false) {
-      startHealthMonitor();
-    }
+    // Everything below runs BEFORE app.listen() resolves, so anything awaited
+    // here delays the port bind — and a runtime that has not bound is
+    // indistinguishable from a dead one to the desktop's health probe, which
+    // kills and respawns it. That is the livelock that bricked a 1.9GB install.
+    //
+    // The app auto-start below already had to be moved off this path for
+    // exactly that reason; the worker starts never were. They are started in
+    // the background now, in order, with each phase published so the splash can
+    // say what it is waiting for instead of showing a bare spinner.
+    //
+    // Ordering is preserved: these ran sequentially before and some assume the
+    // store is open, so they stay sequential — just off the bind path.
+    // Exposed as `app.runtimeBootComplete` so a caller that genuinely needs the
+    // workers running (tests, and anything that used to rely on onReady
+    // awaiting them) can wait for it. "Listening" and "background boot
+    // finished" are different events now, and both are worth being able to
+    // await — conflating them is what put the DB open on the bind path.
+    bootCompletePromise = (async () => {
+      const steps: Array<[string, () => Promise<unknown> | unknown]> = [
+        ["terminal_sessions", () => terminalSessionManager?.start()],
+        ["durable_memory", () => durableMemoryWorker?.start()],
+        ["queue_worker", () => queueWorker?.start()],
+        ["cron_worker", () => cronWorker?.start()],
+        ["main_session_events", () => mainSessionEventWorker?.start()],
+        ["recall_embeddings", () => recallEmbeddingBackfillWorker?.start()],
+        ["channel_gateway", () => channelGatewayManager.start()],
+      ];
+      for (const [phase, run] of steps) {
+        enterBootPhase(phase);
+        try {
+          await run();
+        } catch (err) {
+          // One worker failing to start must not strand the rest — or the boot
+          // phase, which would leave the splash waiting forever on a phase that
+          // never advances.
+          app.log.error(
+            { phase, err: err instanceof Error ? err.message : String(err) },
+            `runtime boot: ${phase} failed to start`,
+          );
+        }
+      }
+      if (options.enableAppHealthMonitor !== false) {
+        startHealthMonitor();
+      }
+      enterBootPhase("ready");
+      bootReady = true;
+      app.log.info(
+        { totalMs: Date.now() - bootStartedAtMs, phases: bootPhaseHistory },
+        `runtime boot: ready in ${Date.now() - bootStartedAtMs}ms`,
+      );
+    })();
 
     // Background DB retention sweep: prune the append-only session_output_events
     // log (age + per-session cap) and, once enough is freed, request a one-time
@@ -4786,6 +4873,27 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
 
 
   app.get("/healthz", async () => ({ ok: true }));
+
+  /**
+   * What the runtime is doing while it starts, and how long it has been doing
+   * it. Unauthed like /healthz, because the desktop polls this before the app
+   * shell (and therefore any auth header) exists.
+   *
+   * `ready` false is NOT a failure — it means "still working". A caller
+   * distinguishes a busy runtime from a hung one by whether `phase` advances,
+   * which is the distinction the boolean /healthz probe cannot express.
+   */
+  // Resolves when the background boot sequence has finished. `app.ready()` only
+  // means the port is about to bind.
+  app.decorate("runtimeBootComplete", () => bootCompletePromise);
+
+  app.get("/runtime/boot-status", async () => ({
+    ready: bootReady,
+    phase: bootPhase,
+    phase_elapsed_ms: Date.now() - bootPhaseStartedAtMs,
+    total_elapsed_ms: Date.now() - bootStartedAtMs,
+    phases: bootPhaseHistory,
+  }));
 
   // Live retention-sweep progress. Unauthed like /healthz — the desktop polls
   // it during boot (before the app shell / auth headers exist) to drive the


### PR DESCRIPTION
Steps 1 and 4 of the boot-UX plan. Two halves of the same user-facing failure: **a boot that is slow is indistinguishable from a boot that is broken** — to the supervisor *and* to the user.

## Off the bind path

Everything awaited in `onReady` runs **before** `app.listen()` resolves, so a slow start delays the port bind. A runtime that hasn't bound looks dead to the desktop's health probe, which kills and respawns it. That's the livelock that bricked a 1.9 GB install.

The reasoning is already in the file — above the app auto-start, which had to be moved off this path for exactly this reason:

> *"Kick app auto-start into the background so the runtime can begin serving /healthz before any workspace app setup/startup work runs. Running this inline inside onReady can delay app.listen() long enough for the desktop bootstrap health check to time out and kill an otherwise healthy runtime."*

The seven worker starts were never moved with it. They now run in the background, in the same order.

**Measured:** `listen()` resolves in ~1s instead of waiting on the full worker chain.

### What this does *not* fix

`better-sqlite3` is **synchronous**, so a long integrity check blocks the event loop and `/healthz` with it — binding earlier doesn't help there. Bounding that check is #507's job. This fixes every *async* start step that sat on the bind path.

## A phase to show

The desktop could see exactly one boot phase (the retention sweep, `heavy && !done`) and rendered a bare splash for everything else. So 80s of honest work looked identical to a hang.

Every phase now publishes to **`/runtime/boot-status`**:

```json
{"ready": false, "phase": "channel_gateway", "phase_elapsed_ms": 120, "total_elapsed_ms": 1840, "phases": [...]}
```

Unauthed, like the other boot probes — the splash polls it before the app shell, and therefore any auth header, exists.

`ready: false` is **not** a failure; it means "still working". A caller distinguishes busy from hung by whether `phase` advances — the distinction the boolean `/healthz` probe cannot express, since `isRuntimeHealthy` collapses connection-refused and 503 to the same `false`.

Each phase is also logged with its duration:

```
runtime boot: terminal_sessions took 34ms
runtime boot: channel_gateway took 0ms
runtime boot: ready in 54ms
```

That alone turns this class of investigation from a process sample into a `grep`.

## API

`app.runtimeBootComplete()` exposes the background boot as awaitable — "listening" and "boot finished" are now genuinely different events and callers should be able to await either. Conflating them is how the DB open ended up on the bind path. Two tests that relied on `onReady` awaiting the workers use it.

## Tests

- the port binds without waiting for the background workers; `/runtime/boot-status` answers immediately with a named phase
- boot-status is reachable without auth, alongside `/healthz` and the maintenance probe

1119 tests, 0 failures.

## Next in the plan

Desktop side: teach `isRuntimeHealthy` the tri-state (ready / starting+phase / unreachable) so it extends patience while a phase advances and shows it on the splash, and add a global retention bound so the DB can't reach gigabytes within policy again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)