### PR TITLE
feat(desktop): remove the cloud-mode UI surface

### DIFF
--- a/apps/desktop/src/components/layout/SettingsScreenRoot.tsx
+++ b/apps/desktop/src/components/layout/SettingsScreenRoot.tsx
@@ -7,7 +7,6 @@ import {
   Copy,
   CreditCard,
   ExternalLink,
-  FlaskConical,
   FolderOpen,
   Globe,
   Info,
@@ -24,7 +23,6 @@ import { useCallback, useEffect, useState } from "react";
 
 import { AuthPanel } from "@/components/auth/AuthPanel";
 import {
-  cloudModeEnabledAtom,
 } from "@/components/layout/shell/state/ui";
 import { BillingSettingsPanel } from "@/components/billing/BillingSettingsPanel";
 import { ChannelsPane } from "@/components/panes/ChannelsPane";
@@ -93,7 +91,6 @@ const SETTINGS_NAV: ReadonlyArray<SettingsScreenNavEntry<UiSettingsPaneSection>>
   { id: "byok", label: "Model Providers", icon: KeyRound },
   { id: "channels", label: "Channels", icon: Send },
   { id: "memory", label: "Memory", icon: BrainCircuit },
-  { id: "experimental", label: "Experimental", icon: FlaskConical },
 ];
 
 const ABOUT_LINKS = [
@@ -137,8 +134,6 @@ function pageTitle(section: UiSettingsPaneSection): string {
       return "Memory";
     case "submissions":
       return "Submissions";
-    case "experimental":
-      return "Experimental";
     default:
       return "General";
   }
@@ -496,8 +491,6 @@ export function SettingsScreenRoot({
         {activeSection === "submissions" ? (
           <SubmissionsPanel initialFocusedId={submissionsFocusId} />
         ) : null}
-
-        {activeSection === "experimental" ? <ExperimentalPanel /> : null}
 
         {activeSection === "settings" ? (
           <>
@@ -972,16 +965,3 @@ function WorkspaceConfigDiagnosticsCard() {
   );
 }
 
-function ExperimentalPanel() {
-  const [cloudModeEnabled, setCloudModeEnabled] = useAtom(cloudModeEnabledAtom);
-  return (
-    <SettingsCard>
-      <SettingsToggle
-        label="Cloud mode"
-        description="Show the Local/Cloud switcher in the sidebar. When off, the switcher is hidden and the sidebar stays in Local mode. Off by default."
-        checked={cloudModeEnabled}
-        onCheckedChange={setCloudModeEnabled}
-      />
-    </SettingsCard>
-  );
-}

--- a/apps/desktop/src/components/layout/shell/AppShell.tsx
+++ b/apps/desktop/src/components/layout/shell/AppShell.tsx
@@ -69,7 +69,7 @@ import {
   selectedSessionIdAtom,
   shortcutsHelpOpenAtom,
   sidebarCollapsedAtom,
-  sidebarModeAtom,
+  effectiveSidebarModeAtom,
   workspaceOverlayAtom,
   type WorkspaceMainViewMode,
 } from "./state/ui";
@@ -148,7 +148,11 @@ function AppShellContent() {
   const layout = useChatLayout();
   const projectView = useAtomValue(projectViewAtom);
   const workspaceOverlay = useAtomValue(workspaceOverlayAtom);
-  const sidebarMode = useAtomValue(sidebarModeAtom);
+  // Reads the EFFECTIVE mode, not the persisted one. Cloud mode is gone from the
+  // UI, but sidebarModeAtom is persisted — a user who tried it still has
+  // "employee" on disk, and acting on that here would point Home at the employee
+  // surface while the sidebar shows Local, with no switcher to escape.
+  const sidebarMode = useAtomValue(effectiveSidebarModeAtom);
   const setWorkspaceOverlay = useSetAtom(workspaceOverlayAtom);
   // The sidebar mode persists across launches but the workspace overlay always
   // defaults to Home = "holahub" (Local's Home). If we relaunched into Employee

--- a/apps/desktop/src/components/layout/shell/Sidebar.tsx
+++ b/apps/desktop/src/components/layout/shell/Sidebar.tsx
@@ -109,11 +109,10 @@ import {
   type CloudSection,
   cloudSectionAtom,
   SIDEBAR_MAX_WIDTH,
-  cloudModeEnabledAtom,
   SIDEBAR_MIN_WIDTH,
   sidebarCollapsedAtom,
   type SidebarMode,
-  sidebarModeAtom,
+  effectiveSidebarModeAtom,
   sidebarWidthAtom,
   workspaceOverlayAtom,
   type WorkspaceOverlay,
@@ -210,48 +209,6 @@ function SidebarResizeHandle() {
     </div>
   );
 }
-// The Local ⇄ Employee segmented switch at the very top of the sidebar. Switching
-// leaves a clean slate and lands each mode on its own Home surface; the choice
-// persists across launches (sidebarModeAtom).
-function SidebarModeToggle() {
-  const [mode, setMode] = useAtom(sidebarModeAtom);
-  const setWorkspaceOverlay = useSetAtom(workspaceOverlayAtom);
-  const setProjectView = useSetAtom(projectViewAtom);
-  const setSelectedSessionId = useSetAtom(selectedSessionIdAtom);
-  const setSelectedEmployee = useSetAtom(selectedEmployeeAtom);
-
-  const switchMode = (next: SidebarMode) => {
-    if (next === mode) {
-      return;
-    }
-    setSelectedEmployee(null);
-    setSelectedSessionId(null);
-    setProjectView(null);
-    setWorkspaceOverlay(next === "employee" ? "holaemployee" : "holahub");
-    setMode(next);
-  };
-
-  return (
-    <div className="mx-2 my-2 grid grid-cols-2 gap-0.5 rounded-lg bg-foreground/5 p-0.5">
-      {(["local", "employee"] as const).map((m) => (
-        <button
-          className={cn(
-            "h-7 rounded-md font-medium text-xs transition-colors",
-            mode === m
-              ? "bg-sidebar text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-          key={m}
-          onClick={() => switchMode(m)}
-          type="button"
-        >
-          {m === "local" ? "Local" : "Employee"}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 // Employee-mode content: a "Home" nav that opens the HolaEmployee page (the old
 // standalone HolaEmployee row, relocated here), then the employee roster + threads.
 // No workspace "New chat" here — starting an employee chat lives on each employee row.
@@ -313,12 +270,9 @@ function SidebarExpanded() {
   // Personal app-store installs are a personal-context concern — shown only in a
   // personal space, not when the desktop is scoped to a real org.
   const { isPersonal } = useOrganizations();
-  const cloudModeEnabled = useAtomValue(cloudModeEnabledAtom);
-  const storedMode = useAtomValue(sidebarModeAtom);
-  // Cloud mode is experimental + off by default. When off, hide the Local/Cloud
-  // switcher and pin the sidebar to Local (a persisted "employee" choice must not
-  // strand the user in a mode with no way back).
-  const mode = cloudModeEnabled ? storedMode : "local";
+  // Cloud mode was removed from the UI; effectiveSidebarModeAtom pins this to
+  // Local for everyone, including users with a persisted "employee" choice.
+  const mode = useAtomValue(effectiveSidebarModeAtom);
   return (
     <aside
       data-pane-card="true"
@@ -338,11 +292,6 @@ function SidebarExpanded() {
         {/* Pinned inside the scroll container so it shares the list's scrollbar
             inset — keeping the switcher edge-aligned with the New chat / nav
             pills regardless of the scrollbar width. */}
-        {cloudModeEnabled ? (
-          <div className="sticky top-0 z-10 flex flex-col bg-sidebar">
-            <SidebarModeToggle />
-          </div>
-        ) : null}
         {mode === "local" ? (
           <>
             <SidebarWorkspaceSection />

--- a/apps/desktop/src/components/layout/shell/state/ui.ts
+++ b/apps/desktop/src/components/layout/shell/state/ui.ts
@@ -56,14 +56,19 @@ export const collapseSidebarForAppSurfaceAtom = atom(null, (_get, set) => {
 });
 
 /**
- * Experimental: Cloud mode — the Local/Cloud sidebar switcher and the cloud
- * surface it reveals. Off by default; when off, the switcher is hidden and the
- * sidebar stays in Local mode. Flip it on in Settings → App → Experimental.
+ * The sidebar's EFFECTIVE mode.
+ *
+ * Cloud mode (the experimental Local/Cloud switcher and the employee surface it
+ * revealed) was removed from the UI. `sidebarModeAtom` is persisted, so anyone
+ * who tried it still has "employee" on disk — and reading that raw would leave
+ * them with a Local sidebar and an Employee main area, stranded in a mode with
+ * no switcher to get back from.
+ *
+ * Everything that renders off the mode reads this instead, so the pin is in one
+ * place rather than re-derived per consumer. Restoring cloud mode means making
+ * this return the stored value again.
  */
-export const cloudModeEnabledAtom = atomWithStorage(
-  "holaboss.experimental.cloud-mode",
-  false,
-);
+export const effectiveSidebarModeAtom = atom<SidebarMode>(() => "local");
 
 /**
  * The middle tab area is maximized to fill the window (sidebar + chat hidden).


### PR DESCRIPTION
Removes the experimental Local/Cloud switcher and the Settings toggle that revealed it.

**Scope: UI only.** The workspace `location: "local" | "cloud"` type, the main-process branches and the control-plane payload are left dormant — so this is reversible and needs no migration. (54 call sites across 6 files were in scope for a full removal; this touches 4 renderer files.)

## Removed

- `cloudModeEnabledAtom`
- **Settings → Experimental** — the cloud toggle was its only content, so the whole section goes with it
- `SidebarModeToggle`, which nothing renders once the switcher is gone

## The part that isn't just deletion

`sidebarModeAtom` is **persisted**, and `AppShell` read it raw to decide whether Home should point at the employee surface:

```ts
if (sidebarMode === "employee") {
  setWorkspaceOverlay((current) => current === "holahub" ? "holaemployee" : current);
}
```

Anyone who ever tried cloud mode still has `"employee"` on disk. Removing only the switcher would have left them with a **Local sidebar and an Employee main area, and no switcher to escape with** — precisely the failure the Sidebar's own comment warned about ("a persisted 'employee' choice must not strand the user in a mode with no way back"). The Sidebar guarded against it locally; AppShell did not.

Both now read `effectiveSidebarModeAtom`, which pins the mode in one place rather than per consumer. Restoring cloud mode means making that atom return the stored value again.

## Deliberately untouched

`cloudSectionAtom` — despite the name it drives the **HolaEmployee** surface's own left nav (`home`/`catalog`/`members`), not cloud workspaces. Pattern-matching on the name would have broken it.

The `selectedWorkspaceNeedsLocalRuntime = selectedWorkspace?.location !== "cloud"` branch stays, along with the guard test in `workspaceDesktop.test.mjs` that pins it.

## Verification

`test:electron` 129/129 · `test:unit` 325/325 · desktop typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)