### PR TITLE
fix(desktop): wait on a boot phase that is advancing, and show it

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4482,6 +4482,13 @@ const RUNTIME_MIGRATION_STARTUP_MESSAGE = "Migrating database";
 const DEFAULT_RUNTIME_STARTUP_HEALTH_ATTEMPTS = 30;
 const MIGRATION_RUNTIME_STARTUP_HEALTH_ATTEMPTS = 900;
 const RUNTIME_STARTUP_HEALTH_DELAY_MS = 1000;
+/**
+ * How long a single boot phase may sit unchanged before it counts as stalled
+ * rather than working. Generous: a phase that is genuinely slow (a large
+ * migration, an integrity check) is exactly what we want to wait for — the
+ * thing worth giving up on is a phase that stops advancing entirely.
+ */
+const STALLED_BOOT_PHASE_ATTEMPTS = 300;
 
 function sqliteTableExists(
   database: Database.Database,
@@ -17317,14 +17324,46 @@ async function waitForRuntimeHealth(
   delayMs = RUNTIME_STARTUP_HEALTH_DELAY_MS,
   options: {
     abortWhen?: () => boolean;
+    /** Called when the runtime moves to a new boot phase, so the splash can say
+     *  what it is waiting for instead of showing a bare spinner. */
+    onPhase?: (status: RuntimeBootStatus) => void;
   } = {},
 ) {
+  // A fixed attempt count races an operation whose duration we do not control,
+  // and the runtime always loses: an integrity check on a large data.db ran ~80s
+  // against this 30s budget, so the desktop killed a runtime that was working,
+  // and the kill left the marker that started the check again. Forever.
+  //
+  // So the budget is no longer blind. While the runtime reports a boot phase
+  // that is CHANGING, it is making progress and gets more time; a phase that
+  // stops moving is the actual "hung" signal, and an unreachable port is the
+  // actual "dead" signal. Runtimes without the endpoint fall back to the plain
+  // attempt count, unchanged.
+  let lastPhase: string | null = null;
+  let attemptsSpentOnThisPhase = 0;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (await isRuntimeHealthy(url)) {
       return true;
     }
     if (options.abortWhen?.()) {
       return false;
+    }
+
+    const status = await fetchRuntimeBootStatus(url);
+    if (status && !status.ready) {
+      if (status.phase !== lastPhase) {
+        // Progress: a new phase resets the patience for it, so the total budget
+        // scales with how much work there is rather than with a guess.
+        lastPhase = status.phase;
+        attemptsSpentOnThisPhase = 0;
+        options.onPhase?.(status);
+      } else {
+        attemptsSpentOnThisPhase += 1;
+      }
+      if (attemptsSpentOnThisPhase < STALLED_BOOT_PHASE_ATTEMPTS) {
+        // Don't count this against the overall budget — it is working.
+        attempt -= 1;
+      }
     }
 
     await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -17360,6 +17399,63 @@ async function isRuntimeHealthy(url: string) {
       resolve(false);
     });
     request.on("error", () => resolve(false));
+    request.end();
+  });
+}
+
+/** What the runtime is doing while it starts. `null` = it did not answer. */
+interface RuntimeBootStatus {
+  ready: boolean;
+  phase: string;
+  phase_elapsed_ms: number;
+  total_elapsed_ms: number;
+}
+
+/**
+ * Read /runtime/boot-status. Absent (404) on runtimes older than the endpoint,
+ * which is why every caller treats `null` as "no information" and falls back to
+ * the plain /healthz probe rather than assuming the worst.
+ */
+function fetchRuntimeBootStatus(url: string): Promise<RuntimeBootStatus | null> {
+  return new Promise((resolve) => {
+    const target = new URL("/runtime/boot-status", url);
+    const request = httpRequest(
+      {
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        method: "GET",
+        timeout: 1500,
+      },
+      (response) => {
+        const status = response.statusCode ?? 0;
+        if (status < 200 || status >= 300) {
+          response.resume();
+          resolve(null);
+          return;
+        }
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          try {
+            const parsed = JSON.parse(body) as RuntimeBootStatus;
+            resolve(
+              typeof parsed?.phase === "string" ? parsed : null,
+            );
+          } catch {
+            resolve(null);
+          }
+        });
+      },
+    );
+    request.on("timeout", () => {
+      request.destroy();
+      resolve(null);
+    });
+    request.on("error", () => resolve(null));
     request.end();
   });
 }
@@ -27364,6 +27460,11 @@ app.whenReady().then(async () => {
   );
   handleTrustedIpc("runtime:getDbMaintenance", ["main"], () =>
     fetchDbMaintenanceStatus(),
+  );
+  // Boot phase, for the splash. Fail-open like the maintenance probe: a null
+  // resolves to "no information", never to "blocked".
+  handleTrustedIpc("runtime:getBootStatus", ["main"], () =>
+    fetchRuntimeBootStatus(runtimeBaseUrl()).catch(() => null),
   );
   handleTrustedIpc("runtime:restart", ["main"], async () => {
     await restartEmbeddedRuntimeSafely("manual_restart");

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -377,6 +377,18 @@ interface DbMaintenanceStatusPayload {
 	done: boolean;
 }
 
+/**
+ * What the runtime is doing while it starts. `ready: false` means "still
+ * working", not "failed" — the splash tells busy from hung by whether `phase`
+ * advances.
+ */
+interface RuntimeBootStatusPayload {
+	ready: boolean;
+	phase: string;
+	phase_elapsed_ms: number;
+	total_elapsed_ms: number;
+}
+
 interface RuntimeConfigPayload {
 	configPath: string | null;
 	loadedFromFile: boolean;
@@ -1579,6 +1591,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			ipcRenderer.invoke(
 				"runtime:getDbMaintenance",
 			) as Promise<DbMaintenanceStatusPayload | null>,
+		getBootStatus: () =>
+			ipcRenderer.invoke(
+				"runtime:getBootStatus",
+			) as Promise<RuntimeBootStatusPayload | null>,
 		restart: () =>
 			ipcRenderer.invoke("runtime:restart") as Promise<RuntimeStatusPayload>,
 		getConfig: () =>

--- a/apps/desktop/electron/runtime-boot-patience.test.mjs
+++ b/apps/desktop/electron/runtime-boot-patience.test.mjs
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mainSource = await readFile(path.join(__dirname, "main.ts"), "utf8");
+
+/**
+ * A fixed attempt count racing an operation whose duration nobody controls is a
+ * race the runtime always loses. On a 1.9GB data.db an integrity check ran ~80s
+ * against this 30s budget: the desktop killed a runtime that was working, and
+ * the kill left the marker that started the check again — forever, with a bare
+ * spinner as the only symptom.
+ */
+
+test("the startup probe distinguishes a busy runtime from a dead one", async () => {
+  // /healthz answers a boolean, so it cannot express "starting". The boot-status
+  // probe is what carries the phase.
+  assert.match(mainSource, /function fetchRuntimeBootStatus\(/);
+  assert.match(
+    mainSource,
+    /\/runtime\/boot-status/,
+    "the desktop must read the runtime's boot phase",
+  );
+});
+
+test("a boot phase that is advancing does not burn the attempt budget", async () => {
+  const start = mainSource.indexOf("async function waitForRuntimeHealth(");
+  assert.notEqual(start, -1);
+  const body = mainSource.slice(start, mainSource.indexOf("\n}\n", start));
+
+  // Progress must refund the attempt — otherwise a slow-but-working boot is
+  // killed on a timer, which is the whole bug.
+  assert.match(
+    body,
+    /attempt -= 1/,
+    "an advancing phase must not count against the overall budget",
+  );
+  assert.match(
+    body,
+    /status\.phase !== lastPhase/,
+    "patience is keyed on the phase CHANGING, not on elapsed time",
+  );
+  // …but a phase that stops moving still has to end the wait, or a genuinely
+  // hung runtime would be waited on forever.
+  assert.match(body, /STALLED_BOOT_PHASE_ATTEMPTS/);
+});
+
+test("a runtime without the boot-status endpoint keeps the old behaviour", async () => {
+  const start = mainSource.indexOf("async function waitForRuntimeHealth(");
+  const body = mainSource.slice(start, mainSource.indexOf("\n}\n", start));
+  // Older runtimes 404 it. `status` is null there, and the extension is gated on
+  // a truthy status, so the plain attempt count still applies.
+  assert.match(
+    body,
+    /if \(status && !status\.ready\)/,
+    "the patience extension must be gated on the runtime actually reporting a phase",
+  );
+});

--- a/apps/desktop/electron/runtime-startup-status.test.mjs
+++ b/apps/desktop/electron/runtime-startup-status.test.mjs
@@ -77,9 +77,12 @@ test("desktop migration startup detection keys off the workspace legacy backfill
 test("desktop runtime health wait can abort early after the spawned runtime exits", async () => {
   const source = await readFile(mainSourcePath, "utf8");
 
+  // Pins that the abort hook EXISTS, not that it is the only option — the
+  // options object also carries onPhase now, and a guard that breaks whenever a
+  // sibling option is added is pinning formatting rather than behaviour.
   assert.match(
     source,
-    /async function waitForRuntimeHealth\([\s\S]*options:\s*\{\s*abortWhen\?: \(\) => boolean;\s*\}\s*=\s*\{\s*\}/,
+    /async function waitForRuntimeHealth\([\s\S]*?abortWhen\?: \(\) => boolean;/,
   );
   assert.match(
     source,

--- a/apps/desktop/src/components/layout/shell/BootGate.tsx
+++ b/apps/desktop/src/components/layout/shell/BootGate.tsx
@@ -20,6 +20,24 @@ const UNKNOWN_STATUS_GRACE_MS = 20_000;
  * glitch can never strand the user here. Entry is latched — once in, a later
  * runtime restart uses the in-shell status banner, not a re-blanked splash.
  */
+/**
+ * Phase names the runtime publishes, in words a user can act on. A boot that is
+ * slow is not a boot that has failed — but with a bare spinner those are the
+ * same picture, and force-quitting a working runtime is what left a corrupt
+ * marker behind and started the crash loop in the first place.
+ */
+const BOOT_PHASE_LABELS: Record<string, string> = {
+  starting: "Starting the runtime…",
+  terminal_sessions: "Restoring terminal sessions…",
+  durable_memory: "Loading memory…",
+  queue_worker: "Starting the task queue…",
+  cron_worker: "Scheduling automations…",
+  main_session_events: "Restoring sessions…",
+  recall_embeddings: "Preparing recall…",
+  channel_gateway: "Connecting channels…",
+  ready: "",
+};
+
 export function BootGate({ children }: { children: ReactNode }) {
   const { runtimeStatus } = useWorkspaceDesktop();
   const status = runtimeStatus?.status ?? null;
@@ -28,6 +46,8 @@ export function BootGate({ children }: { children: ReactNode }) {
   const [maintenance, setMaintenance] =
     useState<DbMaintenanceStatusPayload | null>(null);
   const [maintenanceChecked, setMaintenanceChecked] = useState(false);
+  const [bootStatus, setBootStatus] =
+    useState<RuntimeBootStatusPayload | null>(null);
   const [graceElapsed, setGraceElapsed] = useState(false);
 
   // Fail-open timer for a status that never resolves.
@@ -45,6 +65,7 @@ export function BootGate({ children }: { children: ReactNode }) {
     if (entered || status !== "running") {
       return;
     }
+    const getBootStatus = window.electronAPI?.runtime?.getBootStatus;
     const getDbMaintenance = window.electronAPI?.runtime?.getDbMaintenance;
     if (!getDbMaintenance) {
       // No IPC (web/dev shell) → never block on maintenance.
@@ -57,6 +78,14 @@ export function BootGate({ children }: { children: ReactNode }) {
         const next = await getDbMaintenance();
         if (alive) {
           setMaintenance(next);
+        }
+        // Best-effort and independent: an older runtime has no boot-status
+        // endpoint, and a missing phase must never hold the splash.
+        if (getBootStatus) {
+          const boot = await getBootStatus().catch(() => null);
+          if (alive) {
+            setBootStatus(boot);
+          }
         }
       } catch {
         if (alive) {
@@ -112,9 +141,15 @@ export function BootGate({ children }: { children: ReactNode }) {
     );
   }
 
+  // Prefer the runtime's own startup message (migrations already set one), then
+  // the boot phase, then nothing. Anything is better than a bare spinner.
+  const phaseLabel =
+    bootStatus && !bootStatus.ready
+      ? (BOOT_PHASE_LABELS[bootStatus.phase] ?? "Starting the runtime…")
+      : "";
   return (
     <BootSplash
-      message={runtimeStatus?.startupMessage?.trim() || ""}
+      message={runtimeStatus?.startupMessage?.trim() || phaseLabel}
     />
   );
 }

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -509,6 +509,18 @@ declare global {
 		done: boolean;
 	}
 
+	/**
+	 * What the runtime is doing while it starts. `ready: false` is not a failure
+	 * — it means "still working"; the splash distinguishes a busy runtime from a
+	 * hung one by whether `phase` advances.
+	 */
+	interface RuntimeBootStatusPayload {
+		ready: boolean;
+		phase: string;
+		phase_elapsed_ms: number;
+		total_elapsed_ms: number;
+	}
+
 	interface RuntimeConfigPayload {
 		configPath: string | null;
 		loadedFromFile: boolean;
@@ -2366,6 +2378,7 @@ declare global {
 		runtime: {
 			getStatus: () => Promise<RuntimeStatusPayload>;
 			getDbMaintenance: () => Promise<DbMaintenanceStatusPayload | null>;
+			getBootStatus: () => Promise<RuntimeBootStatusPayload | null>;
 			restart: () => Promise<RuntimeStatusPayload>;
 			getConfig: () => Promise<RuntimeConfigPayload>;
 			refreshModelCatalog: () => Promise<RuntimeConfigPayload>;


### PR DESCRIPTION
Step 2 — the desktop half of the contract #508 added. Without it the runtime publishes a phase nobody reads.

## Patience

A fixed attempt count racing an operation whose duration nobody controls is a race the runtime always loses. On a 1.9 GB `data.db` the integrity check ran **~80s** against a **30 attempt × 1s** budget: the desktop killed a runtime that was working, and the kill left the marker that started the check again. Forever.

`waitForRuntimeHealth` now reads `/runtime/boot-status`:

- while the phase is **changing**, the runtime is making progress → the attempt is refunded, so the budget scales with how much work there is rather than with a guess
- a phase that stops advancing for `STALLED_BOOT_PHASE_ATTEMPTS` is the real **hung** signal
- an unreachable port is still the real **dead** signal

Those are the two things `/healthz`'s boolean cannot tell apart — `isRuntimeHealthy` collapses connection-refused and "busy" into the same `false`.

**Backward compatible:** older runtimes 404 the endpoint, `status` is `null`, and the plain attempt count applies unchanged. A guard test pins that, because it's the case that silently regresses.

## Something to show

`BootGate` had exactly one phase it could render (the retention sweep) and a bare spinner for everything else — so 80s of honest work looked identical to a hang. And force-quitting a working runtime is *how the unclean marker got there in the first place*, which makes the missing information part of the failure loop, not just cosmetic.

It now maps the runtime's phase to a sentence — "Restoring sessions…", "Connecting channels…", "Preparing recall…". Best-effort throughout: a missing endpoint or a failed poll renders nothing rather than holding the splash.

## One guard rewritten

An existing test pinned `waitForRuntimeHealth`'s options object to *exactly* `{ abortWhen }`. Adding any sibling option broke it. Rewritten to assert the abort hook **exists** rather than that it is the only member — a guard that breaks on a neighbouring addition is pinning formatting, not behaviour.

## Verification

`test:electron` 132/132 · `test:unit` 325/325 · typecheck clean.

## Remaining from the plan

Step 5: a **global** retention bound. 162 scheduled sessions reached 1.9 GB entirely within policy — the per-session cap can't stop N sessions summing to gigabytes, and boot cost scales with the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)