### PR TITLE
fix(runtime): bound output-event retention globally, not just per session

### DIFF
--- a/runtime/api-server/src/db-maintenance.test.ts
+++ b/runtime/api-server/src/db-maintenance.test.ts
@@ -9,7 +9,13 @@ import {
 
 /** In-memory fake of the retention surface — no native DB needed. */
 class FakeStore implements DbMaintenanceStore {
-  outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 100 };
+  outputEventRetentionPolicy = {
+    maxAgeDays: 30,
+    maxEventsPerSession: 100,
+    // Off unless a test opts in, so the existing age/cap cases keep measuring
+    // exactly what they measured before.
+    maxTotalEvents: 0,
+  };
   // sessionId -> array of event createdAt ISO strings (id order == array order).
   events = new Map<string, string[]>();
   compactionRequests = 0;
@@ -21,6 +27,34 @@ class FakeStore implements DbMaintenanceStore {
       arr.push(createdAt);
     }
     this.events.set(sessionId, arr);
+  }
+
+  countRootOutputEvents(): number {
+    let total = 0;
+    for (const arr of this.events.values()) {
+      total += arr.length;
+    }
+    return total;
+  }
+
+  /** Oldest-first across all sessions, mirroring the real DELETE ... ORDER BY id. */
+  trimRootOutputEventsToTotal(params: { keep: number; limit: number }): number {
+    const excess = this.countRootOutputEvents() - params.keep;
+    if (excess <= 0) {
+      return 0;
+    }
+    let toDelete = Math.min(excess, params.limit);
+    let deleted = 0;
+    for (const [sessionId, arr] of this.events) {
+      if (toDelete <= 0) {
+        break;
+      }
+      const take = Math.min(toDelete, arr.length);
+      this.events.set(sessionId, arr.slice(take));
+      deleted += take;
+      toDelete -= take;
+    }
+    return deleted;
   }
 
   pruneRootOutputEventsByAge(params: { cutoffIso: string; limit: number }): number {
@@ -92,7 +126,7 @@ const fastOpts = { startDelayMs: 0, pauseMs: 0, now: () => NOW };
 
 test("age prune deletes everything older than the cutoff, in batches", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0, maxTotalEvents: 0 };
   // 250 old events (older than 30d) + 10 recent — batchSize 100 forces 3 passes.
   store.seed("s1", 250, "2026-01-01T00:00:00.000Z");
   store.seed("s1", 10, "2026-07-02T00:00:00.000Z");
@@ -110,7 +144,7 @@ test("age prune deletes everything older than the cutoff, in batches", async () 
 
 test("per-session cap trims heaviest sessions down to the cap", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100, maxTotalEvents: 0 };
   store.seed("big", 350, "2026-07-02T00:00:00.000Z");
   store.seed("ok", 40, "2026-07-02T00:00:00.000Z");
 
@@ -128,7 +162,7 @@ test("per-session cap trims heaviest sessions down to the cap", async () => {
 
 test("requests a compaction once enough rows are freed", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100, maxTotalEvents: 0 };
   store.seed("big", 1100, "2026-07-02T00:00:00.000Z");
 
   const result = await runRuntimeDbMaintenance({
@@ -145,7 +179,7 @@ test("requests a compaction once enough rows are freed", async () => {
 
 test("does NOT request compaction below the free-rows threshold", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100, maxTotalEvents: 0 };
   store.seed("big", 150, "2026-07-02T00:00:00.000Z");
 
   const result = await runRuntimeDbMaintenance({
@@ -162,7 +196,7 @@ test("does NOT request compaction below the free-rows threshold", async () => {
 
 test("a transient lock is retried, not fatal", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 100, maxTotalEvents: 0 };
   store.seed("big", 200, "2026-07-02T00:00:00.000Z");
   store.failNextTrim = 2; // first two trim calls throw "database is locked"
 
@@ -180,7 +214,7 @@ test("a transient lock is retried, not fatal", async () => {
 
 test("flags a heavy sweep up front and reports draining progress to done", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0, maxTotalEvents: 0 };
   // 1000 expired events; threshold 500 → heavy.
   store.seed("s1", 1000, "2026-01-01T00:00:00.000Z");
 
@@ -218,7 +252,7 @@ test("flags a heavy sweep up front and reports draining progress to done", async
 
 test("a small backlog is not heavy (stays a silent background sweep)", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0, maxTotalEvents: 0 };
   store.seed("s1", 100, "2026-01-01T00:00:00.000Z");
 
   const progress: Array<{ heavy: boolean; done: boolean }> = [];
@@ -236,7 +270,7 @@ test("a small backlog is not heavy (stays a silent background sweep)", async () 
 
 test("the loop sweeps repeatedly, not just once at boot", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0, maxTotalEvents: 0 };
 
   // Every sweep emits exactly one "estimating" before it prunes, so counting
   // them counts sweeps. A one-shot implementation never gets past 1 — which is
@@ -268,7 +302,7 @@ test("the loop sweeps repeatedly, not just once at boot", async () => {
 
 test("background sweeps can never raise the blocking boot screen", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0, maxTotalEvents: 0 };
   store.seed("s1", 200, "2026-01-01T00:00:00.000Z");
 
   // BootGate blocks the UI on `heavy && !done`. The first sweep may legitimately
@@ -314,7 +348,7 @@ test("background sweeps can never raise the blocking boot screen", async () => {
 
 test("the loop resolves on abort instead of running forever", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 30, maxEventsPerSession: 0, maxTotalEvents: 0 };
   const controller = new AbortController();
 
   const loop = startRuntimeDbMaintenanceLoop({
@@ -332,7 +366,7 @@ test("the loop resolves on abort instead of running forever", async () => {
 
 test("aborting stops the sweep promptly", async () => {
   const store = new FakeStore();
-  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 0 };
+  store.outputEventRetentionPolicy = { maxAgeDays: 0, maxEventsPerSession: 0, maxTotalEvents: 0 };
   store.seed("s1", 100, "2026-07-02T00:00:00.000Z");
   const controller = new AbortController();
   controller.abort();
@@ -347,4 +381,74 @@ test("aborting stops the sweep promptly", async () => {
 
   assert.equal(result.aborted, true);
   assert.equal(result.compactionRequested, false);
+});
+
+test("a global ceiling bounds the table when every session is within policy", async () => {
+  // The failure this exists for: neither knob bounds the number of SESSIONS.
+  // In the field 162 scheduled sessions each sat at exactly the 25k per-session
+  // cap — 2.29M rows, 1.9GB, every one within policy and NOTHING prunable — and
+  // boot cost scales with the file, so the app could not start.
+  const store = new FakeStore();
+  store.outputEventRetentionPolicy = {
+    maxAgeDays: 30,
+    maxEventsPerSession: 100,
+    maxTotalEvents: 250,
+  };
+  // Five sessions at exactly the per-session cap: age prunes nothing (all
+  // recent), the cap prunes nothing (none exceed it). 500 rows, all legal.
+  const recent = new Date().toISOString();
+  for (let i = 0; i < 5; i++) {
+    store.seed(`scheduled-${i}`, 100, recent);
+  }
+  assert.equal(store.countRootOutputEvents(), 500);
+
+  const result = await runRuntimeDbMaintenance({ store, ...fastOpts, requestCompaction: false });
+
+  assert.equal(result.deletedByAge, 0, "nothing is old enough");
+  assert.equal(result.deletedByCap, 0, "no session exceeds the per-session cap");
+  assert.equal(result.deletedByTotalCap, 250, "the global ceiling is what bounds it");
+  assert.equal(store.countRootOutputEvents(), 250);
+});
+
+test("the global ceiling is off by default in the fake, and a zero disables it", async () => {
+  const store = new FakeStore();
+  store.outputEventRetentionPolicy = {
+    maxAgeDays: 0,
+    maxEventsPerSession: 0,
+    maxTotalEvents: 0,
+  };
+  store.seed("s1", 400, new Date().toISOString());
+
+  const result = await runRuntimeDbMaintenance({ store, ...fastOpts, requestCompaction: false });
+
+  assert.equal(result.deletedByTotalCap, 0, "0 must disable the ceiling, like the other knobs");
+  assert.equal(store.countRootOutputEvents(), 400);
+});
+
+test("the ceiling trims oldest-first, so a quiet session keeps its recent history", async () => {
+  // Trimming the LARGEST sessions instead would let a chatty session evict a
+  // quiet one's newest events. Oldest-first matches what a retention bound
+  // means and matches the age phase.
+  const store = new FakeStore();
+  store.outputEventRetentionPolicy = {
+    maxAgeDays: 0,
+    maxEventsPerSession: 0,
+    maxTotalEvents: 50,
+  };
+  store.seed("old-session", 80, "2026-01-01T00:00:00.000Z");
+  store.seed("recent-session", 20, "2026-08-18T00:00:00.000Z");
+
+  await runRuntimeDbMaintenance({ store, ...fastOpts, requestCompaction: false });
+
+  assert.equal(store.countRootOutputEvents(), 50);
+  assert.equal(
+    store.events.get("recent-session")?.length,
+    20,
+    "the newer session keeps all of its events",
+  );
+  assert.equal(
+    store.events.get("old-session")?.length,
+    30,
+    "the older session absorbs the whole trim",
+  );
 });

--- a/runtime/api-server/src/db-maintenance.ts
+++ b/runtime/api-server/src/db-maintenance.ts
@@ -22,6 +22,8 @@ export interface DbMaintenanceStore {
   listRootSessionsExceedingOutputEventCap(
     cap: number,
   ): Array<{ sessionId: string; count: number }>;
+  countRootOutputEvents(): number;
+  trimRootOutputEventsToTotal(params: { keep: number; limit: number }): number;
   trimSessionOutputEvents(params: {
     workspaceId: string;
     sessionId: string;
@@ -118,6 +120,8 @@ export interface DbMaintenanceResult {
   aborted: boolean;
   deletedByAge: number;
   deletedByCap: number;
+  /** Rows removed by the global ceiling, after the age + per-session phases. */
+  deletedByTotalCap: number;
   compactionRequested: boolean;
 }
 
@@ -157,6 +161,7 @@ export async function runRuntimeDbMaintenance(
     aborted: false,
     deletedByAge: 0,
     deletedByCap: 0,
+    deletedByTotalCap: 0,
     compactionRequested: false,
   };
 
@@ -194,6 +199,19 @@ export async function runRuntimeDbMaintenance(
       )) {
         estimatedRows += Math.max(0, session.count - policy.maxEventsPerSession);
       }
+    }
+    if (policy.maxTotalEvents > 0) {
+      // Counted against the post-cap total, not the raw one: the two phases
+      // above delete some of the same rows, and double-counting them would
+      // inflate the progress bar and could flip a light sweep to "heavy".
+      const remainingAfterOtherPhases = Math.max(
+        0,
+        store.countRootOutputEvents() - estimatedRows,
+      );
+      estimatedRows += Math.max(
+        0,
+        remainingAfterOtherPhases - policy.maxTotalEvents,
+      );
     }
   } catch (error) {
     logger?.error?.("db maintenance: backlog estimate failed", {
@@ -309,13 +327,56 @@ export async function runRuntimeDbMaintenance(
     }
   }
 
+  // Phase 3 — global ceiling. The backstop the other two cannot provide: neither
+  // bounds the number of SESSIONS, so N sessions each sitting exactly at the
+  // per-session cap is "within policy" and still unbounded. That is precisely
+  // what happened — 162 scheduled sessions at 25k each, 1.9GB, nothing prunable
+  // — and boot cost scales with the file, so it bricked the app.
+  //
+  // Runs last so it only ever trims what the cheaper, more targeted phases left
+  // behind.
+  if (policy.maxTotalEvents > 0 && !signal?.aborted) {
+    let consecutiveErrors = 0;
+    while (!signal?.aborted) {
+      let deleted = 0;
+      try {
+        deleted = store.trimRootOutputEventsToTotal({
+          keep: policy.maxTotalEvents,
+          limit: batchSize,
+        });
+        consecutiveErrors = 0;
+      } catch (error) {
+        if (!isTransientLock(error) || ++consecutiveErrors > MAX_CONSECUTIVE_ERRORS) {
+          logger?.error?.("db maintenance: global cap trim aborted", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          break;
+        }
+        if (!(await wait(pauseMs * consecutiveErrors))) {
+          break;
+        }
+        continue;
+      }
+      if (deleted === 0) {
+        break;
+      }
+      result.deletedByTotalCap += deleted;
+      emitProgress("pruning", false);
+      if (!(await wait(pauseMs))) {
+        break;
+      }
+    }
+  }
+
   result.aborted = Boolean(signal?.aborted);
 
-  const totalDeleted = result.deletedByAge + result.deletedByCap;
+  const totalDeleted =
+    result.deletedByAge + result.deletedByCap + result.deletedByTotalCap;
   if (totalDeleted > 0) {
     logger?.info?.("db maintenance: output-event retention sweep complete", {
       deletedByAge: result.deletedByAge,
       deletedByCap: result.deletedByCap,
+      deletedByTotalCap: result.deletedByTotalCap,
       aborted: result.aborted,
     });
   }

--- a/runtime/state-store/src/output-event-retention.test.ts
+++ b/runtime/state-store/src/output-event-retention.test.ts
@@ -46,10 +46,15 @@ function eventCount(store: RuntimeStateStore, sessionId: string): number {
   return store.listOutputEvents({ workspaceId: WS, sessionId }).length;
 }
 
-test("default retention policy is 30 days / 25k events", () => {
+test("default retention policy is 30 days / 25k per session / 250k overall", () => {
   assert.deepEqual(DEFAULT_OUTPUT_EVENT_RETENTION, {
     maxAgeDays: 30,
     maxEventsPerSession: 25_000,
+    // The global ceiling is the backstop the other two cannot provide: neither
+    // bounds the number of SESSIONS. 162 scheduled sessions each sitting at
+    // exactly the 25k cap made 2.29M rows / 1.9GB, entirely within policy and
+    // nothing prunable — and boot cost scales with the file.
+    maxTotalEvents: 250_000,
   });
 });
 

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -1120,6 +1120,15 @@ export interface OutputEventRetentionPolicy {
   maxAgeDays: number;
   /** Keep at most this many (newest) events per session. 0 disables the cap. */
   maxEventsPerSession: number;
+  /**
+   * Keep at most this many (newest) events across ALL sessions. 0 disables it.
+   *
+   * The backstop the other two knobs cannot provide: neither bounds the number
+   * of SESSIONS. In the field 162 scheduled sessions each sat at exactly the
+   * 25k per-session cap — 2.29M rows, 1.9GB, entirely within policy and nothing
+   * prunable — and boot cost scales with the file.
+   */
+  maxTotalEvents: number;
 }
 
 /**
@@ -1131,6 +1140,11 @@ export interface OutputEventRetentionPolicy {
 export const DEFAULT_OUTPUT_EVENT_RETENTION: OutputEventRetentionPolicy = {
   maxAgeDays: 30,
   maxEventsPerSession: 25_000,
+  // ~250k events measured out at roughly 200MB on real data (~830 bytes/row),
+  // against the 1.9GB that 2.29M rows produced. Comfortably above real
+  // interactive use — the same install had 19.5k events across every chat it
+  // had ever held — so this only ever bites the runaway case it exists for.
+  maxTotalEvents: 250_000,
 };
 
 /**
@@ -5907,6 +5921,50 @@ export class RuntimeStateStore {
       `)
       .all(cap) as Array<{ sessionId: string; count: number }>;
     return rows;
+  }
+
+  /**
+   * Background-sweep primitive: total output events in the root db.
+   *
+   * The per-session cap cannot bound the FILE. Observed in the field: 162
+   * scheduled sessions each sitting at exactly the 25k cap — 2.29M rows and
+   * 1.9GB, every one of them within policy, and nothing to prune. Boot cost
+   * scales with the file, so "within policy" was still enough to brick the app.
+   */
+  countRootOutputEvents(): number {
+    const row = this.rootRuntimeDb()
+      .prepare(`SELECT COUNT(*) AS n FROM session_output_events`)
+      .get() as { n?: number } | undefined;
+    return row?.n ?? 0;
+  }
+
+  /**
+   * Background-sweep primitive: delete the OLDEST output events in the root db,
+   * up to `limit`, keeping the table at or under `keep` rows total.
+   *
+   * Oldest-first, matching the age-based phase — a global cap means "keep the
+   * newest N overall", and trimming the largest sessions instead would let a
+   * chatty session evict a quiet one's recent history. Returns rows deleted.
+   */
+  trimRootOutputEventsToTotal(params: { keep: number; limit: number }): number {
+    if (params.keep <= 0 || params.limit <= 0) {
+      return 0;
+    }
+    const total = this.countRootOutputEvents();
+    const excess = total - params.keep;
+    if (excess <= 0) {
+      return 0;
+    }
+    const batch = Math.min(excess, params.limit);
+    const result = this.rootRuntimeDb()
+      .prepare(`
+        DELETE FROM session_output_events
+        WHERE id IN (
+          SELECT id FROM session_output_events ORDER BY id ASC LIMIT ?
+        )
+      `)
+      .run(batch);
+    return result.changes ?? 0;
   }
 
   latestOutputEventId(params: { workspaceId: string; sessionId: string; inputId?: string; excludedEventTypes?: string[] }): number {


### PR DESCRIPTION
Step 5, the last of the boot-UX plan.

## The gap

Retention had two knobs — an age cutoff and a per-session cap — and **neither bounds the number of sessions**. So N sessions each sitting exactly at the cap is "fully within policy" and still unbounded.

Not hypothetical. On the install that couldn't boot:

| | |
|---|---:|
| scheduled sessions | **162** |
| events each | **exactly 25,000** (the cap) |
| total rows | 2,290,128 |
| `data.db` | **1.9 GB** |
| prunable by age | **0** (all inside 30 days) |
| prunable by cap | **0** (none exceeded it) |

A retention sweep with nothing to do, on a database whose size is what bricked the app — because boot cost scales with the file. `quick_check` took 80s against a 30s supervisor budget, and the kill re-armed the check.

## The fix

`maxTotalEvents`, default **250,000** (0 disables, like the other knobs), enforced by a third sweep phase.

250k measured at roughly **200 MB** on real data (~830 bytes/row) against the 1.9 GB that 2.29M rows produced. The same install held just **19,497** events across every interactive chat it had ever had — so this only ever bites the runaway case it exists for.

**Oldest-first across all sessions**, matching the age phase and what a retention bound means. Trimming the *largest* sessions instead would let a chatty session evict a quiet one's newest history — there's a test for exactly that.

**Runs last**, so it only removes what the cheaper, more targeted phases left behind. Its estimate is taken against the *post-cap* total, so the progress bar isn't double-counted and a light sweep can't be misreported as `heavy` (which would raise the blocking boot screen for no reason).

## Tests

- a global ceiling bounds the table when every session is within policy — the exact field shape: 5 sessions at exactly the per-session cap, age and cap both prune nothing, the ceiling is what bounds it
- `0` disables it, like the other knobs
- oldest-first: the quiet session keeps all its events, the old one absorbs the whole trim

state-store 146/146 · api-server 1122, 0 failures · all 8 tasks green.

## The plan is now complete

| | |
|---|---|
| #507 | the check can't livelock |
| #508 | workers off the bind path + phase channel |
| #510 | patience keyed on progress + phase on the splash |
| **this** | the growth that started it can't recur |

🤖 Generated with [Claude Code](https://claude.com/claude-code)