### PR TITLE
fix(desktop): stop the answer vanishing for a moment when a run finishes

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -214,6 +214,10 @@ import {
   normalizeErrorMessage,
   turnInputIdsFromHistoryMessages,
 } from "./helpers";
+import {
+  preserveCommittedAssistantTurns,
+  settleCommittedAssistantTurns,
+} from "./preserveCommittedAssistantTurns";
 import { HistoryRestoreSkeleton } from "./skeletons";
 import { ApiKeyInstallGate } from "./ApiKeyInstallGate";
 import { AttachmentList, formatAttachmentSize } from "./AttachmentList";
@@ -3800,6 +3804,9 @@ export function ChatPane({
 
   const [isPaneDragActive, setIsPaneDragActive] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  /** Assistant turns committed locally that the server has not returned yet.
+   *  The assistant-side counterpart of pendingOptimisticUserMessagesRef. */
+  const pendingCommittedAssistantTurnsRef = useRef<ChatMessage[]>([]);
   const [sessionOutputs, setSessionOutputs] = useState<
     WorkspaceOutputRecordPayload[]
   >([]);
@@ -4417,6 +4424,9 @@ export function ChatPane({
 
   function clearSessionView() {
     setMessages([]);
+    // Scoped to the session it was committed in — leaving it set would splice a
+    // turn from the previous conversation into the next one.
+    pendingCommittedAssistantTurnsRef.current = [];
     setSessionOutputs([]);
     setLoadedHistoryMessageCount(0);
     setTotalHistoryMessageCount(0);
@@ -4733,12 +4743,21 @@ export function ChatPane({
         { workspaceId, sessionId: nextSessionId, persistedInputIds },
       );
       updatePendingOptimisticUserMessagesState(reconciled);
+      // A turn the server has caught up on is no longer pending — its copy is
+      // authoritative from here.
+      pendingCommittedAssistantTurnsRef.current = settleCommittedAssistantTurns(
+        pendingCommittedAssistantTurnsRef.current,
+        renderedForDisplay,
+      );
       setMessages((prev) =>
         preserveDisplayedTurnOutputs(
-          mergePendingOptimisticUserMessages(renderedForDisplay, reconciled, {
-            workspaceId,
-            sessionId: nextSessionId,
-          }),
+          preserveCommittedAssistantTurns(
+            mergePendingOptimisticUserMessages(renderedForDisplay, reconciled, {
+              workspaceId,
+              sessionId: nextSessionId,
+            }),
+            pendingCommittedAssistantTurnsRef.current,
+          ),
           prev,
         ),
       );
@@ -5195,6 +5214,13 @@ export function ChatPane({
     }
 
     setMessages((prev) => [...prev, nextMessage]);
+    // Hold it against the refresh ladder below: the runtime persists this turn
+    // asynchronously, so the 150ms refresh usually cannot see it yet and would
+    // otherwise drop it until the 500ms one — the end-of-response flicker.
+    pendingCommittedAssistantTurnsRef.current = [
+      ...pendingCommittedAssistantTurnsRef.current,
+      nextMessage,
+    ];
     resetLiveTurn();
     return true;
   }

--- a/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ChatMessage } from "./types";
+import {
+  preserveCommittedAssistantTurns,
+  settleCommittedAssistantTurns,
+} from "./preserveCommittedAssistantTurns";
+
+function user(id: string): ChatMessage {
+  return { id, role: "user", text: "hi", createdAt: "2026-08-18T00:00:00.000Z" } as ChatMessage;
+}
+
+function assistant(id: string, text = "answer"): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    text,
+    createdAt: "2026-08-18T00:00:01.000Z",
+  } as ChatMessage;
+}
+
+test("a just-committed turn survives a refresh that predates its persistence", () => {
+  // The flicker: the run finishes, the turn is committed locally, and the 150ms
+  // refresh lands before the runtime has persisted it. Without this the turn is
+  // dropped and only returns on the 500ms refresh.
+  const serverHistory = [user("user-1")];
+  const pending = [assistant("assistant-input-1")];
+
+  const merged = preserveCommittedAssistantTurns(serverHistory, pending);
+
+  assert.deepEqual(
+    merged.map((m) => m.id),
+    ["user-1", "assistant-input-1"],
+    "the committed turn stays on screen, after the user message that prompted it",
+  );
+});
+
+test("the server's copy wins once it arrives", () => {
+  // The server's turn carries outputs, provenance and ids the local one never
+  // had, so it must not be shadowed or duplicated by the pending copy.
+  const serverHistory = [user("user-1"), assistant("assistant-input-1", "server text")];
+  const pending = [assistant("assistant-input-1", "local text")];
+
+  const merged = preserveCommittedAssistantTurns(serverHistory, pending);
+
+  assert.equal(merged.length, 2, "no duplicate turn");
+  assert.equal(
+    merged.find((m) => m.id === "assistant-input-1")?.text,
+    "server text",
+    "the persisted copy is authoritative",
+  );
+});
+
+test("a settled turn stops being held, so a later deletion is not undone", () => {
+  // Without settling, a turn the user later deletes server-side would be
+  // re-appended by every subsequent refresh, forever.
+  const pending = [assistant("assistant-input-1")];
+
+  const settled = settleCommittedAssistantTurns(pending, [
+    user("user-1"),
+    assistant("assistant-input-1"),
+  ]);
+  assert.deepEqual(settled, [], "the server caught up, so nothing is held");
+
+  // A later refresh without the turn (it was deleted) must leave it gone.
+  assert.deepEqual(
+    preserveCommittedAssistantTurns([user("user-1")], settled).map((m) => m.id),
+    ["user-1"],
+    "a deleted turn is not resurrected",
+  );
+});
+
+test("nothing pending is a pass-through, identity included", () => {
+  // The common case by far — every refresh outside the completion window. It
+  // must not allocate a new array, or it would defeat downstream memoization.
+  const serverHistory = [user("user-1"), assistant("assistant-input-1")];
+
+  assert.equal(
+    preserveCommittedAssistantTurns(serverHistory, []),
+    serverHistory,
+    "same array reference when there is nothing to hold",
+  );
+  assert.equal(
+    preserveCommittedAssistantTurns(serverHistory, [assistant("assistant-input-1")]),
+    serverHistory,
+    "same array reference when everything pending has already landed",
+  );
+});
+
+test("several turns can be in flight at once", () => {
+  // Two runs completing in quick succession, neither persisted yet.
+  const merged = preserveCommittedAssistantTurns(
+    [user("user-1")],
+    [assistant("assistant-input-1"), assistant("assistant-input-2")],
+  );
+  assert.deepEqual(merged.map((m) => m.id), [
+    "user-1",
+    "assistant-input-1",
+    "assistant-input-2",
+  ]);
+});

--- a/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.ts
+++ b/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.ts
@@ -1,0 +1,59 @@
+import type { ChatMessage } from "./types";
+
+/**
+ * Keep a just-finished assistant turn on screen until the server's history
+ * catches up with it.
+ *
+ * When a run completes, the turn is committed straight into local state so it
+ * appears the instant streaming stops. The conversation is then refreshed on a
+ * ladder (150ms / 500ms / 1.5s / 3s) because the runtime persists the turn
+ * asynchronously — deliberately so, since that relay was moved off the turn's
+ * critical path.
+ *
+ * The 150ms refresh therefore usually arrives BEFORE the turn is queryable, and
+ * it replaces the message list with the server's. The existing helpers do not
+ * cover this: `mergePendingOptimisticUserMessages` re-adds pending USER
+ * messages, and `preserveDisplayedTurnOutputs` maps over the server list, so a
+ * message missing from it is simply dropped. The turn vanishes and reappears
+ * ~350ms later on the next refresh — the flicker users see at the end of every
+ * response.
+ *
+ * User messages already have exactly this protection. This is the assistant
+ * half of that symmetry: hold locally committed turns until the persisted turn
+ * shows up, then let the server's copy win.
+ */
+export function preserveCommittedAssistantTurns(
+  next: ChatMessage[],
+  pending: ChatMessage[],
+): ChatMessage[] {
+  if (pending.length === 0) {
+    return next;
+  }
+  const present = new Set(next.map((message) => message.id));
+  // Anything the server now returns is authoritative — its copy carries
+  // outputs, provenance and ids the local one never had, so a still-pending
+  // turn is only appended while genuinely absent.
+  const missing = pending.filter((message) => !present.has(message.id));
+  if (missing.length === 0) {
+    return next;
+  }
+  // Appended, not spliced: these are always the newest turn in the session, and
+  // the refresh that dropped them is by definition missing the tail.
+  return [...next, ...missing];
+}
+
+/**
+ * Drop the turns the server has caught up on. Called with each refresh's
+ * rendered history so the pending set stays bounded and a turn that was later
+ * deleted server-side cannot be resurrected forever.
+ */
+export function settleCommittedAssistantTurns(
+  pending: ChatMessage[],
+  rendered: ChatMessage[],
+): ChatMessage[] {
+  if (pending.length === 0) {
+    return pending;
+  }
+  const present = new Set(rendered.map((message) => message.id));
+  return pending.filter((message) => !present.has(message.id));
+}


### PR DESCRIPTION
Reported as *"after the agent finishes outputting, it would disappear for a second then back"*. It does. Here is the window:

1. The run completes and the turn is committed straight into local state (`ChatPane/index.tsx:5197`), so it appears the instant streaming stops.
2. `scheduleConversationRefresh` fires refreshes at **150 ms / 500 ms / 1.5 s / 3 s** (`:5245`) — a ladder that exists *precisely because* the runtime persists the turn asynchronously. That relay was deliberately moved off the turn's critical path in #493.
3. So the 150 ms refresh usually lands **before the turn is queryable**, and replaces the message list with the server's history.
4. Neither existing guard covers it:
   - `mergePendingOptimisticUserMessages` re-adds pending **user** messages
   - `preserveDisplayedTurnOutputs` **maps over the server list**, so a message missing from it is simply dropped
5. The turn returns on the 500 ms refresh.

That ~350 ms gap is the flicker.

## The asymmetry is the bug

User messages already have exactly this protection — `PendingOptimisticUserMessage` + `reconcilePendingOptimisticUserMessages`, held across refresh "until the persisted message arrives". Assistant turns had none. This adds the other half of that symmetry.

## Behaviour

- A committed turn is held until the server returns one with the same id.
- Then **the server's copy wins outright** — it carries outputs, provenance and ids the local one never had.
- **Settling** on every refresh keeps the set bounded, and means a turn deleted server-side stays deleted rather than being re-appended by every subsequent refresh forever.
- **Cleared on session switch**, so a turn cannot splice into the next conversation.
- The no-op path returns the **same array reference**, so the common case — every refresh outside the completion window — cannot defeat downstream memoization.

## Tests

Five, including the ones that stop this becoming a worse bug than it fixes: the server copy winning rather than duplicating, a deleted turn not being resurrected, and reference identity on the no-op path.

`test:unit` 330/330 · `test:electron` 132/132 · typecheck clean.

## Not in this PR

Two further findings from the same scan, both about the ladder rather than the flicker:

- **Four full history refetches per completed turn**, each re-deriving every message from scratch. On a long conversation that is the general stutter.
- **Identity churn defeats memoization** — every refresh produces new message objects, so `React.memo` comparators downstream (including the one fixed in #484) always miss.

Fixing those means collapsing the ladder and preserving object identity for unchanged turns; worth doing separately from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)