### PR TITLE
perf(desktop): stop the refresh ladder once the turn it waits for lands

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -5156,10 +5156,13 @@ export function ChatPane({
     });
   }
 
+  /** Returns the committed message id, or null when there was nothing to
+   *  commit. Callers that only need "did it commit?" still read it as a
+   *  boolean; the id lets the refresh ladder name the turn it is waiting for. */
   function commitLiveAssistantMessage(options?: {
     fallbackText?: string;
     tone?: ChatMessage["tone"];
-  }) {
+  }): string | null {
     const messageId =
       activeAssistantMessageIdRef.current ?? `assistant-${Date.now()}`;
     let nextSegments = liveAssistantSegmentsRef.current;
@@ -5192,7 +5195,7 @@ export function ChatPane({
 
     if (nextSegments.length === 0) {
       resetLiveTurn();
-      return false;
+      return null;
     }
 
     const nextMessage: ChatMessage = {
@@ -5210,7 +5213,7 @@ export function ChatPane({
       })
     ) {
       resetLiveTurn();
-      return false;
+      return null;
     }
 
     setMessages((prev) => [...prev, nextMessage]);
@@ -5222,7 +5225,7 @@ export function ChatPane({
       nextMessage,
     ];
     resetLiveTurn();
-    return true;
+    return messageId;
   }
 
   // Coalesce overlapping refreshes: at most one load runs at a time, with a
@@ -5261,6 +5264,11 @@ export function ChatPane({
   function scheduleConversationRefresh(
     sessionId: string | null,
     workspaceId: string | null | undefined,
+    options?: {
+      /** The turn this ladder is waiting for the runtime to persist. Once it
+       *  lands, the remaining refreshes have nothing left to converge on. */
+      awaitAssistantMessageId?: string | null;
+    },
   ) {
     const normalizedSessionId = (sessionId || "").trim();
     const normalizedWorkspaceId = (workspaceId || "").trim();
@@ -5268,11 +5276,45 @@ export function ChatPane({
       return;
     }
 
+    // The ladder covers an unknown persistence delay, so it retries on a curve
+    // rather than once. But every rung re-derives the WHOLE conversation, so
+    // running all four unconditionally costs three full rebuilds of every
+    // message after the data has already converged — the bulk of the
+    // end-of-turn stutter on a long chat.
+    //
+    // When the caller names the turn it is waiting for, stop as soon as that
+    // turn lands. Callers that name nothing keep the old behaviour exactly.
     const delays = [150, 500, 1_500, 3_000];
+    const timers: number[] = [];
+    const awaited = (options?.awaitAssistantMessageId ?? "").trim();
+    const cancelRemaining = () => {
+      for (const timer of timers) {
+        window.clearTimeout(timer);
+      }
+      timers.length = 0;
+    };
     for (const delayMs of delays) {
-      window.setTimeout(() => {
-        void runConversationRefresh(normalizedSessionId, normalizedWorkspaceId);
-      }, delayMs);
+      timers.push(
+        window.setTimeout(() => {
+          void runConversationRefresh(
+            normalizedSessionId,
+            normalizedWorkspaceId,
+          ).then(() => {
+            if (!awaited) {
+              return;
+            }
+            // Settled by the refresh itself (see settleCommittedAssistantTurns)
+            // the moment the server returns the turn.
+            const stillPending =
+              pendingCommittedAssistantTurnsRef.current.some(
+                (message) => message.id === awaited,
+              );
+            if (!stillPending) {
+              cancelRemaining();
+            }
+          });
+        }, delayMs),
+      );
     }
   }
 
@@ -6866,7 +6908,9 @@ export function ChatPane({
             action: "applied_run_completed",
             detail: "run completed",
           });
-          scheduleConversationRefresh(eventSessionId, selectedWorkspaceId);
+          scheduleConversationRefresh(eventSessionId, selectedWorkspaceId, {
+            awaitAssistantMessageId: committedAssistantMessage,
+          });
           void refreshWorkspaceData().catch(() => undefined);
         }
       },

--- a/apps/desktop/src/components/panes/ChatPane/refreshLadder.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/refreshLadder.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, "index.tsx"), "utf-8");
+
+/**
+ * STRUCTURAL guard, in a `.test.ts` deliberately: `src/**` + `/*.test.mjs` is
+ * gated by no CI job — `test:electron` globs `electron/`, `test:unit` globs
+ * `.test.ts`/`.test.tsx` — so a guard written as `.mjs` under src/ would never
+ * run. (ChatPane.test.mjs currently has 50 failing assertions nobody sees.)
+ */
+
+test("the refresh ladder stops once the turn it waits for has landed", () => {
+  // Every rung re-derives the WHOLE conversation, so running all four
+  // unconditionally costs three full rebuilds of every message after the data
+  // has already converged — the bulk of the end-of-turn stutter on a long chat.
+  assert.match(
+    source,
+    /const delays = \[150, 500, 1_500, 3_000\];/,
+    "the retry curve stays — the persistence delay is still unknown",
+  );
+  assert.match(
+    source,
+    /const cancelRemaining = \(\) => \{[\s\S]*?window\.clearTimeout\(timer\)/,
+    "the remaining rungs must be cancellable",
+  );
+  // Keyed on the awaited turn actually landing, not on a timer or a count.
+  assert.match(
+    source,
+    /const stillPending =\s*pendingCommittedAssistantTurnsRef\.current\.some\(\s*\(message\) => message\.id === awaited,\s*\);\s*if \(!stillPending\) \{\s*cancelRemaining\(\);/,
+  );
+});
+
+test("a ladder that names no turn still runs every rung", () => {
+  // run_failed and the other callers converge on things this signal knows
+  // nothing about, so they must keep the old behaviour exactly.
+  assert.match(source, /if \(!awaited\) \{\s*return;\s*\}/);
+});
+
+test("the completion path names the turn it is waiting for", () => {
+  assert.match(
+    source,
+    /scheduleConversationRefresh\(eventSessionId, selectedWorkspaceId, \{\s*awaitAssistantMessageId: committedAssistantMessage,\s*\}\);/,
+  );
+  // Which requires the commit to hand back an id rather than a bare boolean.
+  assert.match(
+    source,
+    /function commitLiveAssistantMessage\(options\?: \{[\s\S]*?\}\): string \| null \{/,
+  );
+});


### PR DESCRIPTION
Second of the three findings from the smoothness scan. #512 fixed the visible flicker; this is the cost behind the general stutter.

## The cost

Every completed turn scheduled **four full conversation refreshes** — 150 ms / 500 ms / 1.5 s / 3 s — and each rung re-derives the **entire conversation** from scratch via `chatMessagesFromSessionState`.

The curve exists because the runtime persists the turn asynchronously and the delay is unknown. But the rungs ran unconditionally, so after the data converged (usually by the second rung) the remaining ones were **three complete rebuilds of every message, for nothing** — and the cost scales with conversation length, which matches "laggy here and there" getting worse in long chats.

## The change

The ladder now takes the turn it is waiting for and stops as soon as that turn lands.

#512 already tracks exactly that — a turn settles out of `pendingCommittedAssistantTurnsRef` the moment the server returns it — so the signal was free. This only reads it.

**Deliberately narrow:** callers that name no turn (`run_failed` and the other convergence paths, which wait on things this signal knows nothing about) keep the old behaviour exactly, retry curve included. Only the completion path names a turn, because it's the only one that knows which.

`commitLiveAssistantMessage` returns the committed id instead of a bare boolean so the completion path can name it. Every existing caller reads the result only for truthiness and a non-empty id is truthy, so none of them change.

## On the guard's location

It's a `.test.ts`, not the `.mjs` beside it. `src/**` + `/*.test.mjs` is gated by **no CI job** — `test:electron` globs `electron/`, `test:unit` globs `.test.ts`/`.test.tsx` — so a guard written there would never run. `ChatPane.test.mjs` has **50 failing assertions** nobody sees for exactly that reason; worth fixing separately.

`test:unit` 333/333 · `test:electron` 132/132 · typecheck clean.

## Still open from the scan

**Identity churn defeats memoization.** Every refresh produces brand-new message objects, so `displayMessages`' `useMemo` never holds and every `React.memo` comparator downstream always misses — including the one fixed in #484. Until derived messages preserve object identity for unchanged turns, memoization downstream cannot pay off. That's the last of the three and the most invasive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)