### PR TITLE
perf(desktop): keep message identity across refreshes so memoization works

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -218,6 +218,7 @@ import {
   preserveCommittedAssistantTurns,
   settleCommittedAssistantTurns,
 } from "./preserveCommittedAssistantTurns";
+import { preserveMessageIdentity } from "./preserveMessageIdentity";
 import { HistoryRestoreSkeleton } from "./skeletons";
 import { ApiKeyInstallGate } from "./ApiKeyInstallGate";
 import { AttachmentList, formatAttachmentSize } from "./AttachmentList";
@@ -4750,13 +4751,18 @@ export function ChatPane({
         renderedForDisplay,
       );
       setMessages((prev) =>
-        preserveDisplayedTurnOutputs(
-          preserveCommittedAssistantTurns(
-            mergePendingOptimisticUserMessages(renderedForDisplay, reconciled, {
-              workspaceId,
-              sessionId: nextSessionId,
-            }),
-            pendingCommittedAssistantTurnsRef.current,
+        // Outermost: everything below rebuilds objects, so identity is restored
+        // last, once the final content is settled.
+        preserveMessageIdentity(
+          preserveDisplayedTurnOutputs(
+            preserveCommittedAssistantTurns(
+              mergePendingOptimisticUserMessages(renderedForDisplay, reconciled, {
+                workspaceId,
+                sessionId: nextSessionId,
+              }),
+              pendingCommittedAssistantTurnsRef.current,
+            ),
+            prev,
           ),
           prev,
         ),

--- a/apps/desktop/src/components/panes/ChatPane/preserveMessageIdentity.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/preserveMessageIdentity.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ChatMessage } from "./types";
+import { preserveMessageIdentity } from "./preserveMessageIdentity";
+
+function message(id: string, overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    text: "answer",
+    createdAt: "2026-08-18T00:00:00.000Z",
+    segments: [{ kind: "output", text: "answer", tone: "default" }],
+    ...overrides,
+  } as ChatMessage;
+}
+
+test("an unchanged turn keeps the object React already has", () => {
+  // This is the whole point: AssistantTurn's memo comparator compares props BY
+  // REFERENCE, so a rebuilt-but-identical message re-renders the turn and
+  // re-runs markdown + syntax highlighting for nothing.
+  const prev = [message("a"), message("b")];
+  const rebuilt = [message("a"), message("b")]; // same content, new objects
+
+  const merged = preserveMessageIdentity(rebuilt, prev);
+
+  assert.equal(merged[0], prev[0], "unchanged turn keeps its identity");
+  assert.equal(merged[1], prev[1]);
+});
+
+test("a no-op refresh returns the previous ARRAY, so the useMemo above holds too", () => {
+  const prev = [message("a"), message("b")];
+  const rebuilt = [message("a"), message("b")];
+
+  assert.equal(
+    preserveMessageIdentity(rebuilt, prev),
+    prev,
+    "identical list → same array reference → displayMessages' memo holds",
+  );
+});
+
+test("a changed turn is NOT pinned to its stale object", () => {
+  // The dangerous failure direction: preserving too eagerly would freeze the
+  // old content on screen.
+  const prev = [message("a", { text: "old" })];
+  const rebuilt = [message("a", { text: "new" })];
+
+  const merged = preserveMessageIdentity(rebuilt, prev);
+
+  assert.equal(merged[0], rebuilt[0], "the changed turn uses the fresh object");
+  assert.equal((merged[0] as { text: string }).text, "new");
+});
+
+test("a change buried in a nested field still counts as changed", () => {
+  // A hand-written field-by-field comparison rots the moment a new field is
+  // added — it silently reports "equal" and pins stale content. This is why
+  // the comparison is structural.
+  const prev = [message("a", { segments: [{ kind: "output", text: "old", tone: "default" }] })];
+  const rebuilt = [message("a", { segments: [{ kind: "output", text: "new", tone: "default" }] })];
+
+  const merged = preserveMessageIdentity(rebuilt, prev);
+
+  assert.equal(merged[0], rebuilt[0], "a nested difference must not be preserved away");
+});
+
+test("appended turns do not disturb the identity of earlier ones", () => {
+  // The common case during a conversation: one new turn arrives, everything
+  // before it should stay put and stay memoized.
+  const prev = [message("a"), message("b")];
+  const rebuilt = [message("a"), message("b"), message("c")];
+
+  const merged = preserveMessageIdentity(rebuilt, prev);
+
+  assert.equal(merged.length, 3);
+  assert.equal(merged[0], prev[0], "earlier turns keep identity");
+  assert.equal(merged[1], prev[1]);
+  assert.equal(merged[2], rebuilt[2], "the new turn is the fresh object");
+  assert.notEqual(merged, prev, "a longer list is a new array");
+});
+
+test("a removed turn is really removed", () => {
+  const prev = [message("a"), message("b")];
+  const rebuilt = [message("a")];
+
+  const merged = preserveMessageIdentity(rebuilt, prev);
+
+  assert.deepEqual(merged.map((m) => m.id), ["a"]);
+  assert.equal(merged[0], prev[0]);
+});
+
+test("empty inputs are pass-throughs", () => {
+  const rebuilt = [message("a")];
+  assert.equal(preserveMessageIdentity(rebuilt, []), rebuilt);
+  assert.deepEqual(preserveMessageIdentity([], [message("a")]), []);
+});
+
+test("role changing on the same id is treated as changed", () => {
+  const prev = [message("a", { role: "user" })];
+  const rebuilt = [message("a", { role: "assistant" })];
+  assert.equal(preserveMessageIdentity(rebuilt, prev)[0], rebuilt[0]);
+});

--- a/apps/desktop/src/components/panes/ChatPane/preserveMessageIdentity.ts
+++ b/apps/desktop/src/components/panes/ChatPane/preserveMessageIdentity.ts
@@ -1,0 +1,88 @@
+import type { ChatMessage } from "./types";
+
+/**
+ * Return the PREVIOUS object for any message whose content is unchanged.
+ *
+ * Every conversation refresh rebuilds the whole message list from raw payloads,
+ * so even a turn that has not changed in an hour comes back as a brand-new
+ * object with brand-new `segments` / `outputs` / `executionItems` arrays. That
+ * defeats memoization from the top down:
+ *
+ *  - `displayMessages` is `useMemo`'d on `[messages]`, and `messages` is a new
+ *    array every time, so the memo never holds.
+ *  - `AssistantTurn` is wrapped in `React.memo` with a comparator that compares
+ *    those props BY REFERENCE, so every message re-renders on every refresh —
+ *    re-running markdown and syntax highlighting for the entire conversation.
+ *
+ * Making the comparator smarter cannot fix that; the inputs genuinely are new
+ * objects. The fix is upstream: hand back the object React already has when
+ * nothing about it changed. Then the reference comparisons start succeeding and
+ * the existing memoization does what it was written to do.
+ *
+ * Returns the previous ARRAY too when every message was preserved, so the
+ * `useMemo` above it also holds and a no-op refresh costs no re-render at all.
+ */
+export function preserveMessageIdentity(
+  next: ChatMessage[],
+  prev: ChatMessage[],
+): ChatMessage[] {
+  if (prev.length === 0 || next.length === 0) {
+    return next;
+  }
+  const prevById = new Map<string, ChatMessage>();
+  for (const message of prev) {
+    prevById.set(message.id, message);
+  }
+
+  let changed = false;
+  const merged = next.map((message) => {
+    const previous = prevById.get(message.id);
+    if (previous && previous !== message && isSameRenderedMessage(previous, message)) {
+      return previous;
+    }
+    if (previous !== message) {
+      changed = true;
+    }
+    return message;
+  });
+
+  // Same messages, same order → hand back the array React already has.
+  if (!changed && merged.length === prev.length) {
+    let identical = true;
+    for (let i = 0; i < merged.length; i += 1) {
+      if (merged[i] !== prev[i]) {
+        identical = false;
+        break;
+      }
+    }
+    if (identical) {
+      return prev;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Structural equality over what a turn actually renders.
+ *
+ * Compared by serialization rather than field-by-field on purpose: a turn's
+ * shape keeps growing (segments, executionItems, outputs, pendingIntegrations,
+ * mcpAuthorizations, publishedPosts, backgroundTaskReferences…) and a
+ * hand-written comparison silently rots into "equal" for whichever field was
+ * added last — which would pin stale content on screen. Being wrong in that
+ * direction is far worse than the comparison cost, which is proportional to the
+ * message we just built anyway, and is paid once per refresh instead of once
+ * per render.
+ */
+function isSameRenderedMessage(a: ChatMessage, b: ChatMessage): boolean {
+  if (a.id !== b.id || a.role !== b.role) {
+    return false;
+  }
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    // Non-serializable (cyclic) message: treat as changed rather than risk
+    // pinning stale content.
+    return false;
+  }
+}


### PR DESCRIPTION
Last of the three findings from the smoothness scan — and the one that makes the *other* memoization pay.

## The problem

Every conversation refresh rebuilds the whole list from raw payloads, so a turn untouched for an hour comes back as a **new object with new `segments` / `outputs` / `executionItems` arrays**. That defeats memoization from the top down:

- `displayMessages` is `useMemo`'d on `[messages]`, and `messages` is a new array every time → the memo never holds.
- `AssistantTurn` is `React.memo`'d with a comparator that compares those props **by reference** → every message re-renders on every refresh, re-running markdown and syntax highlighting for the entire conversation.

Making the comparator smarter cannot fix this; the inputs genuinely *are* new objects. #484 fixed a real bug in that comparator this morning and **still couldn't hit**, because nothing upstream preserved identity.

## The change

Hand back the object React already has when nothing about the message changed — and hand back the **previous array** when nothing changed at all, so a no-op refresh costs no re-render instead of a full conversation rebuild.

Verified end-to-end that a preserved message satisfies every prop the comparator checks by reference:

```
array identity preserved: true
every reference-compared prop hits: true
```

Applied as the **outermost** step of the merge, after the existing `preserve*` helpers, since each of those rebuilds objects too.

## On the equality check

Structural (serialization), not field-by-field, deliberately. A turn's shape keeps growing — `segments`, `executionItems`, `outputs`, `pendingIntegrations`, `mcpAuthorizations`, `publishedPosts`, `backgroundTaskReferences` — and a hand-written comparison silently rots into "equal" for whichever field was added last, which would **pin stale content on screen**.

Being wrong in that direction is far worse than the comparison cost, which is proportional to the message we just built anyway and is paid once per refresh rather than once per render. There's a test for a change buried in a nested field specifically, and one for the dangerous direction (a changed turn must not keep its stale object).

`test:unit` 341/341 · `test:electron` 132/132 · typecheck clean.

## The scan, complete

| | |
|---|---|
| #512 | the answer no longer vanishes at the end of a run |
| #513 | four full refreshes per turn → stops as soon as the turn lands |
| **this** | unchanged turns stop re-rendering at all |

🤖 Generated with [Claude Code](https://claude.com/claude-code)