### PR TITLE
test(desktop): repair the two guards today's merges broke

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane.test.mjs
+++ b/apps/desktop/src/components/panes/ChatPane.test.mjs
@@ -648,7 +648,7 @@ test("chat pane polling can clear a stale stream after runtime reaches terminal 
   );
   assert.match(
     source,
-    /status === "WAITING_USER" \|\| status === "PAUSED"[\s\S]*commitLiveAssistantMessage\(\);[\s\S]*scheduleConversationRefresh\(normalizedCurrentSessionId, selectedWorkspaceId\);/,
+    /status === "WAITING_USER" \|\| status === "PAUSED"[\s\S]*commitLiveAssistantMessage\(\);[\s\S]*scheduleConversationRefresh\(\s*normalizedCurrentSessionId,\s*selectedWorkspaceId,?\s*\);/,
   );
   assert.match(
     source,

--- a/apps/desktop/src/lib/workspaceDesktop.test.mjs
+++ b/apps/desktop/src/lib/workspaceDesktop.test.mjs
@@ -146,7 +146,7 @@ test("workspace desktop re-activates workspaces while installed apps are still s
 
 	assert.match(
 		source,
-		/const hasInitializing = installedApps\.some\(\(app\) => !app\.ready\);/,
+		/const hasInitializingApps = installedApps\.some\(\(app\) => !app\.ready\);/,
 	);
 	assert.match(
 		source,


### PR DESCRIPTION
Both live in `src/**/*.test.mjs`, which **no CI job runs** — so neither failure was visible when the change that caused it landed.

- **`workspaceDesktop`** — #500 renamed `hasInitializing` → `hasInitializingApps` and hoisted it out of the effect so the poll could key on the derived boolean. Behaviour intact and better; the guard just pinned the old name.
- **`ChatPane`** — the guard pinned `scheduleConversationRefresh(a, b);` on one line; a formatter has since wrapped it across three. The call itself is unchanged, so the assertion is now whitespace-tolerant rather than re-pinning a line break.

These are **2 of 115** failures across the 64 ungated files. The rest are pre-existing — see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)