### PR TITLE
feat(runtime): alarm on a slow boot instead of only describing one

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -17341,6 +17341,8 @@ async function waitForRuntimeHealth(
   // attempt count, unchanged.
   let lastPhase: string | null = null;
   let attemptsSpentOnThisPhase = 0;
+  // One warning per phase: a line per poll for 80s buries the log it annotates.
+  let overBudgetPhaseLogged = false;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (await isRuntimeHealthy(url)) {
       return true;
@@ -17356,9 +17358,22 @@ async function waitForRuntimeHealth(
         // scales with how much work there is rather than with a guess.
         lastPhase = status.phase;
         attemptsSpentOnThisPhase = 0;
+        overBudgetPhaseLogged = false;
         options.onPhase?.(status);
       } else {
         attemptsSpentOnThisPhase += 1;
+      }
+      // Mirror the runtime's own alarm into THIS log. The runtime warns in
+      // runtime.log, but the desktop log is the one that comes back attached to
+      // a bug report, and "the app hung on launch" is exactly the report where
+      // knowing which phase overran is the whole diagnosis.
+      if (status.phase_over_budget && !overBudgetPhaseLogged) {
+        overBudgetPhaseLogged = true;
+        console.warn(
+          `[runtime] boot phase "${status.phase}" is over budget: ${status.phase_elapsed_ms}ms` +
+            (status.phase_budget_ms ? ` (budget ${status.phase_budget_ms}ms)` : "") +
+            ` — still advancing, so not treating it as dead`,
+        );
       }
       if (attemptsSpentOnThisPhase < STALLED_BOOT_PHASE_ATTEMPTS) {
         // Don't count this against the overall budget — it is working.
@@ -17409,6 +17424,11 @@ interface RuntimeBootStatus {
   phase: string;
   phase_elapsed_ms: number;
   total_elapsed_ms: number;
+  /** Budget for the current phase, and whether it has been exceeded. Optional:
+   *  a runtime older than the budgets simply omits them, and every reader here
+   *  treats absent as "no opinion" rather than as "fine". */
+  phase_budget_ms?: number;
+  phase_over_budget?: boolean;
 }
 
 /**

--- a/apps/docs/MOVED.md
+++ b/apps/docs/MOVED.md
@@ -1,0 +1,11 @@
+# Docs moved
+
+The Holaboss documentation site has moved to the **holaboss-frontend** monorepo
+(`apps/docs`), where it deploys to the `holaboss-docs-*` Cloudflare Workers as
+part of that repo's `.github/workflows/deploy.yml` (push `develop` → staging,
+`main` → production).
+
+This copy under `holaOS/apps/docs` is **retired**. Its `deploy:*` scripts have
+been disarmed (they exit 1) so nobody accidentally publishes stale content over
+the worker that holaboss-frontend now owns. The source is kept here only as
+history — do not deploy it, and make content changes in holaboss-frontend.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,9 +11,9 @@
     "lint": "biome check",
     "format": "biome format --write",
     "cf:types": "wrangler types --env-interface Env",
-    "deploy:preview": "bun run build && wrangler deploy --env preview",
-    "deploy:staging": "bun run build && wrangler deploy --env staging",
-    "deploy:production": "bun run build && wrangler deploy --env production"
+    "deploy:preview": "echo 'RETIRED: the docs moved to the holaboss-frontend monorepo (apps/docs). Deploy from there (bun run deploy:docs:staging|:production). See apps/docs/MOVED.md.' && exit 1",
+    "deploy:staging": "echo 'RETIRED: the docs moved to the holaboss-frontend monorepo (apps/docs). Deploy from there (bun run deploy:docs:staging|:production). See apps/docs/MOVED.md.' && exit 1",
+    "deploy:production": "echo 'RETIRED: the docs moved to the holaboss-frontend monorepo (apps/docs). Deploy from there (bun run deploy:docs:staging|:production). See apps/docs/MOVED.md.' && exit 1"
   },
   "dependencies": {
     "@fontsource-variable/geist-mono": "^5.2.7",

--- a/runtime/api-server/src/app.test.ts
+++ b/runtime/api-server/src/app.test.ts
@@ -17,6 +17,7 @@ import yazl from "yazl";
 import * as tar from "tar";
 
 import { buildRuntimeApiServer, type BuildRuntimeApiServerOptions } from "./app.js";
+import { parseBootHistory } from "./boot-telemetry.js";
 import { appLocalNpmCacheDir, buildAppSetupEnv } from "./app-setup-env.js";
 import { processClaimedInput } from "./claimed-input-executor.js";
 import { runtimeUserTimezone } from "./cron-worker.js";
@@ -14432,6 +14433,77 @@ test("boot-status is reachable without auth, like the other boot probes", async 
       process.env.SANDBOX_RUNTIME_API_TOKEN = previousToken;
     }
     await app!.close();
+    store.close();
+  }
+});
+
+test("boot-status publishes the phase budget so slow can be told from stuck", async () => {
+  // Steps 1-5 made boot observable; this is what makes it judgeable. The
+  // supervisor already refunds attempts while the phase advances, so a slow
+  // phase is not killed — but without a budget on the wire, neither it nor the
+  // splash can say anything more useful than "still working". Publishing the
+  // budget keeps that table in one place instead of duplicated on the desktop.
+  const root = makeTempDir("hb-runtime-api-boot-budget-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const app = buildTestRuntimeApiServer({ store });
+  try {
+    await app.ready();
+    const response = await app.inject({ method: "GET", url: "/runtime/boot-status" });
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      phase: string;
+      phase_budget_ms: number;
+      phase_over_budget: boolean;
+      alarms: unknown[];
+    };
+    assert.ok(
+      Number.isFinite(body.phase_budget_ms) && body.phase_budget_ms > 0,
+      "every phase has a budget, including ones added later",
+    );
+    assert.equal(typeof body.phase_over_budget, "boolean");
+    assert.ok(Array.isArray(body.alarms));
+  } finally {
+    await app.close();
+    store.close();
+  }
+});
+
+test("a healthy boot records its timings and raises no alarm", async () => {
+  // The baseline half of the alarm: without a persisted history, "slow" can only
+  // ever mean "past an absolute threshold", which either cries wolf on a slow
+  // disk or never fires on a fast one.
+  const root = makeTempDir("hb-runtime-api-boot-telemetry-");
+  const store = new RuntimeStateStore({
+    dbPath: path.join(root, "runtime.db"),
+    workspaceRoot: path.join(root, "workspace"),
+  });
+  const app = buildTestRuntimeApiServer({ store });
+  try {
+    await app.ready();
+    await app.runtimeBootComplete();
+
+    const body = (
+      await app.inject({ method: "GET", url: "/runtime/boot-status" })
+    ).json() as { ready: boolean; alarms: unknown[] };
+    assert.equal(body.ready, true);
+    assert.deepEqual(body.alarms, [], "a test-speed boot is not a slow boot");
+
+    const history = parseBootHistory(store.readBootTimingHistoryJson());
+    assert.equal(history.length, 1, "the boot that just happened is recorded");
+    assert.ok(Number.isFinite(history[0].total_ms));
+    assert.ok(
+      Array.isArray(history[0].phases) && history[0].phases.length > 0,
+      "per-phase timings are kept, so a slow boot is diagnosable from the record alone",
+    );
+    assert.ok(
+      typeof history[0].root_db_open_ms === "number",
+      "the root DB open is attributed to the open, not to whichever worker touched the store first",
+    );
+  } finally {
+    await app.close();
     store.close();
   }
 });

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -136,6 +136,15 @@ import {
   type DbMaintenanceProgress,
 } from "./db-maintenance.js";
 import {
+  appendBootRecord,
+  classifyBoot,
+  parseBootHistory,
+  phaseBudgetMs,
+  phaseOverBudget,
+  type BootAlarm,
+  type BootRecord,
+} from "./boot-telemetry.js";
+import {
   type RecallEmbeddingBackfillWorkerLike,
   RuntimeRecallEmbeddingBackfillWorker,
 } from "./recall-embedding-backfill-worker.js";
@@ -259,6 +268,10 @@ import {
 // without busy-polling. Kept off the hot path, so it's a safety net, not the
 // streaming cadence.
 const STREAM_IDLE_FALLBACK_MS = 250;
+// How often the boot watchdog checks the in-flight phase against its budget.
+// A second is far below every budget, so the warning lands promptly, and the
+// timer is unref'd and cleared at `ready` — it costs nothing after boot.
+const BOOT_WATCHDOG_INTERVAL_MS = 1_000;
 const DEFAULT_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
 const DEFAULT_APP_SETUP_TIMEOUT_MS = 900_000;
 const DEFAULT_TERMINAL_COLS = 120;
@@ -4027,6 +4040,9 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   let bootPhaseStartedAtMs = bootStartedAtMs;
   let bootReady = false;
   const bootPhaseHistory: Array<{ phase: string; ms: number }> = [];
+  const bootAlarms: BootAlarm[] = [];
+  // Phases already warned about, so the watchdog says it once and then stops.
+  const bootPhasesWarned = new Set<string>();
   const enterBootPhase = (phase: string): void => {
     const now = Date.now();
     const previous = bootPhase;
@@ -4041,6 +4057,42 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     bootPhase = phase;
     bootPhaseStartedAtMs = now;
   };
+
+  /**
+   * Watchdog over the IN-FLIGHT phase.
+   *
+   * This is the part that matters. The boot that motivated all of this never
+   * finished — it was SIGKILLed mid-`quick_check` on every attempt — so any
+   * check that runs when boot completes would have stayed silent for precisely
+   * the failure it was written to catch. Polling the current phase against its
+   * budget is the only version of this alarm that fires during the incident
+   * rather than after it.
+   *
+   * Unref'd so it can never hold the process open, and it says each phase once:
+   * a warning per second for 80s buries the log it is trying to annotate.
+   */
+  const bootWatchdog = setInterval(() => {
+    if (bootReady) {
+      return;
+    }
+    const elapsed = Date.now() - bootPhaseStartedAtMs;
+    if (bootPhasesWarned.has(bootPhase) || !phaseOverBudget(bootPhase, elapsed)) {
+      return;
+    }
+    bootPhasesWarned.add(bootPhase);
+    const budget = phaseBudgetMs(bootPhase);
+    app.log.warn(
+      {
+        event: "runtime.boot.phase_over_budget",
+        phase: bootPhase,
+        elapsed_ms: elapsed,
+        budget_ms: budget,
+        total_elapsed_ms: Date.now() - bootStartedAtMs,
+      },
+      `runtime boot: still in ${bootPhase} after ${elapsed}ms (budget ${budget}ms) — this boot is slow, not necessarily stuck`,
+    );
+  }, BOOT_WATCHDOG_INTERVAL_MS);
+  bootWatchdog.unref();
 
   /**
    * Ensures this app's MCP tools are registered in workspace.yaml's
@@ -4803,10 +4855,56 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       }
       enterBootPhase("ready");
       bootReady = true;
+      clearInterval(bootWatchdog);
+      const totalMs = Date.now() - bootStartedAtMs;
       app.log.info(
-        { totalMs: Date.now() - bootStartedAtMs, phases: bootPhaseHistory },
-        `runtime boot: ready in ${Date.now() - bootStartedAtMs}ms`,
+        { totalMs, phases: bootPhaseHistory },
+        `runtime boot: ready in ${totalMs}ms`,
       );
+
+      // Telemetry is strictly an observer: anything it throws would turn a
+      // diagnostic into the outage it exists to diagnose, so the whole block is
+      // guarded and failure is silent beyond a debug line.
+      try {
+        const dbTimings = store.rootRuntimeDbOpenTimings();
+        const record: BootRecord = {
+          total_ms: totalMs,
+          phases: [...bootPhaseHistory],
+          ...(dbTimings.openMs !== null
+            ? { root_db_open_ms: dbTimings.openMs }
+            : {}),
+          ...(dbTimings.integrityCheckMs !== null
+            ? { root_db_integrity_check_ms: dbTimings.integrityCheckMs }
+            : {}),
+          at: new Date().toISOString(),
+        };
+        const history = parseBootHistory(store.readBootTimingHistoryJson());
+        for (const alarm of classifyBoot(record, history)) {
+          bootAlarms.push(alarm);
+          app.log.warn(
+            {
+              event: `runtime.boot.${alarm.kind}`,
+              phase: alarm.phase,
+              elapsed_ms: alarm.elapsed_ms,
+              budget_ms: alarm.budget_ms,
+              baseline_ms: alarm.baseline_ms,
+              root_db_open_ms: record.root_db_open_ms,
+              root_db_integrity_check_ms: record.root_db_integrity_check_ms,
+            },
+            `runtime boot: ${alarm.message}`,
+          );
+        }
+        // Written last: a boot slow enough to be worth alarming about is also
+        // the one whose numbers the next boot needs for its baseline.
+        store.writeBootTimingHistoryJson(
+          JSON.stringify(appendBootRecord(history, record)),
+        );
+      } catch (err) {
+        app.log.debug(
+          { err: err instanceof Error ? err.message : String(err) },
+          "runtime boot: telemetry not recorded",
+        );
+      }
     })();
 
     // Background DB retention sweep: prune the append-only session_output_events
@@ -4887,13 +4985,24 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
   // means the port is about to bind.
   app.decorate("runtimeBootComplete", () => bootCompletePromise);
 
-  app.get("/runtime/boot-status", async () => ({
-    ready: bootReady,
-    phase: bootPhase,
-    phase_elapsed_ms: Date.now() - bootPhaseStartedAtMs,
-    total_elapsed_ms: Date.now() - bootStartedAtMs,
-    phases: bootPhaseHistory,
-  }));
+  app.get("/runtime/boot-status", async () => {
+    const phaseElapsedMs = Date.now() - bootPhaseStartedAtMs;
+    return {
+      ready: bootReady,
+      phase: bootPhase,
+      phase_elapsed_ms: phaseElapsedMs,
+      total_elapsed_ms: Date.now() - bootStartedAtMs,
+      phases: bootPhaseHistory,
+      // Lets the supervisor and the splash distinguish "slow" from "stuck"
+      // without duplicating the budget table on the desktop side. The
+      // supervisor already refunds attempts while the phase advances, so a slow
+      // phase is not killed — this is what makes the waiting honest to the user
+      // instead of a silent spinner.
+      phase_budget_ms: phaseBudgetMs(bootPhase),
+      phase_over_budget: !bootReady && phaseOverBudget(bootPhase, phaseElapsedMs),
+      alarms: bootAlarms,
+    };
+  });
 
   // Live retention-sweep progress. Unauthed like /healthz — the desktop polls
   // it during boot (before the app shell / auth headers exist) to drive the

--- a/runtime/api-server/src/boot-telemetry.test.ts
+++ b/runtime/api-server/src/boot-telemetry.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BASELINE_MIN_MS,
+  BOOT_HISTORY_LIMIT,
+  DEFAULT_PHASE_BUDGET_MS,
+  TOTAL_BOOT_BUDGET_MS,
+  appendBootRecord,
+  baselineTotalMs,
+  classifyBoot,
+  parseBootHistory,
+  phaseBudgetMs,
+  phaseOverBudget,
+  type BootRecord,
+} from "./boot-telemetry.js";
+
+function record(overrides: Partial<BootRecord> = {}): BootRecord {
+  return {
+    total_ms: 1_000,
+    phases: [{ phase: "durable_memory", ms: 500 }],
+    at: "2026-08-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("known phases get their own budget, unknown phases get the default", () => {
+  assert.equal(phaseBudgetMs("durable_memory"), 30_000);
+  assert.equal(phaseBudgetMs("channel_gateway"), 20_000);
+  assert.equal(phaseBudgetMs("a_phase_added_next_year"), DEFAULT_PHASE_BUDGET_MS);
+});
+
+test("phaseOverBudget answers for a phase that has not finished", () => {
+  // The livelock case: the process never reaches the end of this phase, so the
+  // only useful question is about the time spent so far.
+  assert.equal(phaseOverBudget("durable_memory", 29_999), false);
+  assert.equal(phaseOverBudget("durable_memory", 30_001), true);
+});
+
+test("a healthy boot raises nothing", () => {
+  assert.deepEqual(classifyBoot(record()), []);
+});
+
+test("a phase over its own budget is named in the alarm", () => {
+  const alarms = classifyBoot(
+    record({ phases: [{ phase: "queue_worker", ms: 11_000 }] }),
+  );
+  assert.equal(alarms.length, 1);
+  assert.equal(alarms[0].kind, "phase_over_budget");
+  assert.equal(alarms[0].phase, "queue_worker");
+  assert.match(alarms[0].message, /queue_worker took 11000ms/);
+});
+
+test("the total budget fires independently of any single phase", () => {
+  // Death by a thousand cuts: every phase inside its budget, the sum well past
+  // the point a user has given up on the app.
+  const phases = Array.from({ length: 20 }, (_, index) => ({
+    phase: `step_${index}`,
+    ms: 4_000,
+  }));
+  const alarms = classifyBoot(record({ total_ms: 80_000, phases }));
+  assert.equal(alarms.length, 1);
+  assert.equal(alarms[0].kind, "total_over_budget");
+  assert.equal(alarms[0].budget_ms, TOTAL_BOOT_BUDGET_MS);
+});
+
+test("median baseline ignores a single pathological boot", () => {
+  const history = [
+    record({ total_ms: 2_000 }),
+    record({ total_ms: 2_200 }),
+    record({ total_ms: 80_000 }),
+  ];
+  // A mean would be ~28s and would hide every subsequent slow boot.
+  assert.equal(baselineTotalMs(history), 2_200);
+});
+
+test("baseline is null with no usable history", () => {
+  assert.equal(baselineTotalMs([]), null);
+  assert.equal(baselineTotalMs([record({ total_ms: 0 })]), null);
+  assert.equal(baselineTotalMs([record({ total_ms: Number.NaN })]), null);
+});
+
+test("a regression against this machine's own history is reported", () => {
+  const history = Array.from({ length: 5 }, () => record({ total_ms: 4_000 }));
+  const alarms = classifyBoot(record({ total_ms: 20_000 }), history);
+  assert.equal(alarms.length, 1);
+  assert.equal(alarms[0].kind, "slower_than_baseline");
+  assert.equal(alarms[0].baseline_ms, 4_000);
+  assert.match(alarms[0].message, /5\.0x this machine's baseline/);
+});
+
+test("a boot inside the regression factor stays quiet", () => {
+  const history = Array.from({ length: 5 }, () => record({ total_ms: 4_000 }));
+  assert.deepEqual(classifyBoot(record({ total_ms: 11_000 }), history), []);
+});
+
+test("fast machines do not trip the regression alarm on noise", () => {
+  // 40ms -> 200ms is 5x and completely meaningless.
+  const history = Array.from({ length: 5 }, () => record({ total_ms: 40 }));
+  assert.ok(40 < BASELINE_MIN_MS);
+  assert.deepEqual(classifyBoot(record({ total_ms: 200 }), history), []);
+});
+
+test("both an absolute breach and a regression are reported together", () => {
+  // They point at different things — one at a subsystem, one at the data — so
+  // collapsing them would throw away half the signal.
+  const history = Array.from({ length: 5 }, () => record({ total_ms: 4_000 }));
+  const alarms = classifyBoot(
+    record({ total_ms: 90_000, phases: [{ phase: "durable_memory", ms: 85_000 }] }),
+    history,
+  );
+  assert.deepEqual(alarms.map((alarm) => alarm.kind), [
+    "phase_over_budget",
+    "total_over_budget",
+    "slower_than_baseline",
+  ]);
+});
+
+test("history is a bounded ring that drops the oldest", () => {
+  let history: BootRecord[] = [];
+  for (let index = 0; index < BOOT_HISTORY_LIMIT + 5; index += 1) {
+    history = appendBootRecord(history, record({ total_ms: index }));
+  }
+  assert.equal(history.length, BOOT_HISTORY_LIMIT);
+  assert.equal(history[0].total_ms, 5);
+  assert.equal(history.at(-1)?.total_ms, BOOT_HISTORY_LIMIT + 4);
+});
+
+test("parsing a persisted history never throws", () => {
+  // This reads a row an older build wrote. Losing the baseline is acceptable;
+  // failing the boot that is trying to read it is not.
+  assert.deepEqual(parseBootHistory(null), []);
+  assert.deepEqual(parseBootHistory(""), []);
+  assert.deepEqual(parseBootHistory("{not json"), []);
+  assert.deepEqual(parseBootHistory('{"total_ms":1}'), []);
+  assert.deepEqual(parseBootHistory("[1,2,3]"), []);
+  assert.deepEqual(parseBootHistory('[{"total_ms":"slow","phases":[]}]'), []);
+});
+
+test("parsing keeps the well-formed entries and drops the rest", () => {
+  const parsed = parseBootHistory(
+    JSON.stringify([
+      { total_ms: 1_000, phases: [], at: "2026-08-19T00:00:00.000Z" },
+      { total_ms: null, phases: [] },
+      { total_ms: 2_000, phases: [{ phase: "queue_worker", ms: 10 }] },
+    ]),
+  );
+  assert.equal(parsed.length, 2);
+  assert.deepEqual(parsed.map((entry) => entry.total_ms), [1_000, 2_000]);
+});

--- a/runtime/api-server/src/boot-telemetry.ts
+++ b/runtime/api-server/src/boot-telemetry.ts
@@ -1,0 +1,222 @@
+/**
+ * Boot timing telemetry.
+ *
+ * Boot phases became observable when the phase tracker and `/runtime/boot-status`
+ * landed, but every phase logs at the same level: an 800ms boot and an 80s boot
+ * produce identical output, and the timings die with the process. That is how a
+ * 2GB `data.db` spending 80s in `PRAGMA quick_check` went unnoticed until it
+ * bricked the app — the runtime was doing honest work the whole time and nothing
+ * anywhere said "this is not normal".
+ *
+ * Two rules follow from that failure, and they shape this module:
+ *
+ *  1. The alarm has to fire while a phase is STILL RUNNING. The boot that
+ *     motivated this never completed, so any check that only runs at the end
+ *     would have stayed silent for exactly the failure it was written for.
+ *     Hence `phaseBudgetMs` — a budget the caller can poll the in-flight phase
+ *     against, not just compare a finished one to.
+ *
+ *  2. "Slow" is machine-relative. A cold spinning disk and a warm SSD differ by
+ *     more than an order of magnitude, so a single absolute threshold either
+ *     cries wolf on slow hardware or never fires on fast hardware. Absolute
+ *     budgets catch the pathological case; the persisted baseline catches the
+ *     regression that is only visible against this machine's own history.
+ */
+
+/** One completed boot, as persisted. Small and flat on purpose: it is written
+ *  to a KV row as JSON and read back by a later process, so it has to survive
+ *  round-tripping without a schema. */
+export interface BootRecord {
+  /** Wall-clock ms from app construction to `ready`. */
+  total_ms: number;
+  /** Per-phase timings, in the order they ran. */
+  phases: Array<{ phase: string; ms: number }>;
+  /** Time spent opening the root DB, when known. Attributed separately because
+   *  the open is lazy: without this it is charged to whichever background
+   *  worker happened to touch the store first, which reads as "durable_memory
+   *  took 80s" and sends the next person to the wrong file. */
+  root_db_open_ms?: number;
+  /** Time inside `PRAGMA quick_check`, when it ran. The single most expensive
+   *  thing a boot can do, and unbounded in the size of the DB. */
+  root_db_integrity_check_ms?: number;
+  /** ISO timestamp, so a stored history is readable without correlating logs. */
+  at: string;
+}
+
+export interface BootAlarm {
+  kind: "phase_over_budget" | "total_over_budget" | "slower_than_baseline";
+  phase?: string;
+  elapsed_ms: number;
+  budget_ms?: number;
+  baseline_ms?: number;
+  message: string;
+}
+
+/**
+ * Per-phase budgets.
+ *
+ * These are not targets — they are the point at which a phase stops looking
+ * like work and starts looking like a problem worth a line in the log. Set them
+ * generously: a false alarm every boot trains people to ignore the alarm, which
+ * costs more than the alarm was ever worth.
+ */
+export const DEFAULT_PHASE_BUDGET_MS = 5_000;
+
+export const PHASE_BUDGETS_MS: Readonly<Record<string, number>> = Object.freeze({
+  // Opens the root DB on first touch, so it wears the integrity check and any
+  // pending compaction. Generous, because on a large DB this is legitimately
+  // slow — but not unbounded, because unbounded is what bricked the app.
+  durable_memory: 30_000,
+  terminal_sessions: 10_000,
+  // Reaches out to configured channels; a slow network is not a broken boot.
+  channel_gateway: 20_000,
+  queue_worker: 10_000,
+  cron_worker: 10_000,
+  main_session_events: 10_000,
+  recall_embeddings: 10_000,
+});
+
+/** Total boot budget. Past this the app has been showing a spinner long enough
+ *  that a user would reasonably assume it is broken. */
+export const TOTAL_BOOT_BUDGET_MS = 60_000;
+
+/** How many boots to keep. Enough to form a stable median, few enough that the
+ *  row stays small and a single bad boot cannot poison the baseline. */
+export const BOOT_HISTORY_LIMIT = 10;
+
+/** A boot this much slower than the baseline is a regression worth saying out
+ *  loud, even when it is comfortably inside the absolute budget. */
+export const BASELINE_REGRESSION_FACTOR = 3;
+
+/** Below this, ratios are noise — a 40ms boot that becomes 130ms is 3.25x and
+ *  means nothing. Keeps the regression alarm off fast, healthy machines. */
+export const BASELINE_MIN_MS = 1_000;
+
+export function phaseBudgetMs(phase: string): number {
+  return PHASE_BUDGETS_MS[phase] ?? DEFAULT_PHASE_BUDGET_MS;
+}
+
+/**
+ * Is the phase running right now over its budget?
+ *
+ * Deliberately takes the elapsed time rather than a start timestamp so the
+ * caller can poll it from a watchdog on an interval, and so it is trivially
+ * testable without faking a clock.
+ */
+export function phaseOverBudget(phase: string, elapsedMs: number): boolean {
+  return elapsedMs > phaseBudgetMs(phase);
+}
+
+/** Median total, ignoring anything implausible. Median rather than mean so one
+ *  pathological boot (the exact case this exists to catch) does not drag the
+ *  baseline up and hide the next one. */
+export function baselineTotalMs(history: readonly BootRecord[]): number | null {
+  const totals = history
+    .map((record) => record.total_ms)
+    .filter((ms) => Number.isFinite(ms) && ms > 0)
+    .sort((left, right) => left - right);
+  if (totals.length === 0) {
+    return null;
+  }
+  const middle = Math.floor(totals.length / 2);
+  return totals.length % 2 === 1
+    ? totals[middle]
+    : Math.round((totals[middle - 1] + totals[middle]) / 2);
+}
+
+/**
+ * Every reason this boot deserves attention, in severity order.
+ *
+ * Returns a list rather than a boolean because the reasons are not
+ * interchangeable: "one phase blew its budget" points at a subsystem, while
+ * "the whole thing regressed against this machine's own history" points at the
+ * data (a DB that has grown, a disk filling up). Collapsing them to `slow: true`
+ * throws away the half of the signal that says where to look.
+ */
+export function classifyBoot(
+  record: BootRecord,
+  history: readonly BootRecord[] = [],
+): BootAlarm[] {
+  const alarms: BootAlarm[] = [];
+
+  for (const { phase, ms } of record.phases) {
+    if (phaseOverBudget(phase, ms)) {
+      const budget = phaseBudgetMs(phase);
+      alarms.push({
+        kind: "phase_over_budget",
+        phase,
+        elapsed_ms: ms,
+        budget_ms: budget,
+        message: `boot phase ${phase} took ${ms}ms (budget ${budget}ms)`,
+      });
+    }
+  }
+
+  if (record.total_ms > TOTAL_BOOT_BUDGET_MS) {
+    alarms.push({
+      kind: "total_over_budget",
+      elapsed_ms: record.total_ms,
+      budget_ms: TOTAL_BOOT_BUDGET_MS,
+      message: `boot took ${record.total_ms}ms (budget ${TOTAL_BOOT_BUDGET_MS}ms)`,
+    });
+  }
+
+  const baseline = baselineTotalMs(history);
+  if (
+    baseline !== null &&
+    baseline >= BASELINE_MIN_MS &&
+    record.total_ms > baseline * BASELINE_REGRESSION_FACTOR
+  ) {
+    alarms.push({
+      kind: "slower_than_baseline",
+      elapsed_ms: record.total_ms,
+      baseline_ms: baseline,
+      message: `boot took ${record.total_ms}ms, ${(record.total_ms / baseline).toFixed(1)}x this machine's baseline of ${baseline}ms`,
+    });
+  }
+
+  return alarms;
+}
+
+/** Append and trim, oldest first. Pure so the ring's bound is testable without
+ *  a database. */
+export function appendBootRecord(
+  history: readonly BootRecord[],
+  record: BootRecord,
+  limit: number = BOOT_HISTORY_LIMIT,
+): BootRecord[] {
+  const next = [...history, record];
+  return next.length > limit ? next.slice(next.length - limit) : next;
+}
+
+/**
+ * Parse a persisted history, tolerating anything.
+ *
+ * This reads a KV row written by an older build, so it must never throw: a
+ * malformed history is a reason to lose the baseline, not to fail the boot that
+ * is trying to read it. That would turn a telemetry feature into an outage.
+ */
+export function parseBootHistory(raw: string | null | undefined): BootRecord[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry): entry is BootRecord => {
+      if (typeof entry !== "object" || entry === null) {
+        return false;
+      }
+      const candidate = entry as Partial<BootRecord>;
+      return (
+        typeof candidate.total_ms === "number" &&
+        Number.isFinite(candidate.total_ms) &&
+        Array.isArray(candidate.phases)
+      );
+    });
+  } catch {
+    return [];
+  }
+}

--- a/runtime/state-store/src/boot-timing-history.test.ts
+++ b/runtime/state-store/src/boot-timing-history.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import { RuntimeStateStore } from "./store.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeStore(): { store: RuntimeStateStore; root: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "boot-timing-"));
+  tempDirs.push(root);
+  return {
+    store: new RuntimeStateStore({
+      dbPath: path.join(root, "host-state.db"),
+      workspaceRoot: path.join(root, "workspace"),
+    }),
+    root,
+  };
+}
+
+test("boot telemetry never forces the root DB open", () => {
+  // The rule this enforces: the root DB open is the expensive thing boot
+  // telemetry exists to measure (an 80s PRAGMA quick_check on a large data.db),
+  // so a telemetry read that opens it would cause the very failure it reports.
+  // Both accessors decline instead, and the caller loses only its baseline.
+  const { store, root } = makeStore();
+  try {
+    assert.equal(store.readBootTimingHistoryJson(), null);
+    assert.equal(store.writeBootTimingHistoryJson("[]"), false);
+    // The proof: no data.db exists, because nothing opened it.
+    assert.equal(fs.existsSync(path.join(root, "state", "data.db")), false);
+  } finally {
+    store.close();
+  }
+});
+
+test("boot timings round-trip once the root DB is open", () => {
+  const { store } = makeStore();
+  try {
+    // Any real read opens the root DB, which is the normal case at end-of-boot:
+    // the background workers have already touched the store by then.
+    store.countRootOutputEvents();
+
+    assert.equal(store.readBootTimingHistoryJson(), null);
+    const history = JSON.stringify([
+      { total_ms: 1_200, phases: [{ phase: "durable_memory", ms: 900 }], at: "2026-08-19T00:00:00.000Z" },
+    ]);
+    assert.equal(store.writeBootTimingHistoryJson(history), true);
+    assert.equal(store.readBootTimingHistoryJson(), history);
+
+    // Upsert, not append: the ring is bounded by the writer.
+    const replacement = JSON.stringify([{ total_ms: 42, phases: [], at: "x" }]);
+    assert.equal(store.writeBootTimingHistoryJson(replacement), true);
+    assert.equal(store.readBootTimingHistoryJson(), replacement);
+  } finally {
+    store.close();
+  }
+});
+
+test("root DB open timings are recorded once the DB is opened", () => {
+  const { store } = makeStore();
+  try {
+    // Nulls before the open — "not opened" is the honest answer, and reporting
+    // it must not trigger the open.
+    assert.deepEqual(store.rootRuntimeDbOpenTimings(), {
+      openMs: null,
+      integrityCheckMs: null,
+    });
+
+    store.countRootOutputEvents();
+
+    const timings = store.rootRuntimeDbOpenTimings();
+    assert.ok(
+      typeof timings.openMs === "number" && timings.openMs >= 0,
+      "the open should be timed so it is attributed to the open rather than to whichever worker touched the store first",
+    );
+    // A clean first run never runs the integrity check — it only runs after an
+    // unclean exit — so this stays null here.
+    assert.equal(timings.integrityCheckMs, null);
+  } finally {
+    store.close();
+  }
+});

--- a/runtime/state-store/src/store.ts
+++ b/runtime/state-store/src/store.ts
@@ -40,6 +40,10 @@ const WORKSPACE_RUNTIME_LEGACY_BACKFILL_MARKER_KEY =
 // for every legacy workspace_id (INSERT OR IGNORE) on every launch, silently
 // resurrecting projects the user has since deleted.
 const HOST_STATE_MONOLITH_FOLDED_MARKER_KEY = "host_state_monolith_folded_v1";
+// Persisted (root-DB) ring of recent boot timings. Lives in the root so a boot can
+// be compared against THIS machine's own history — an absolute threshold alone
+// either cries wolf on a slow disk or never fires on a fast one.
+const BOOT_TIMING_HISTORY_KEY = "boot_timing_history_v1";
 const MAIN_SESSION_KIND = "main_session";
 const SUBAGENT_SESSION_KIND = "subagent";
 const MAIN_SESSION_BINDING_ROLE = "main_session";
@@ -1611,6 +1615,13 @@ export class RuntimeStateStore {
   #workspaceRuntimeDbs: Map<string, { dbPath: string; db: Database.Database }> = new Map();
   #vectorIndexSupported = false;
   #statementCache: Map<string, Database.Statement> = new Map();
+  // How long the root DB open took, and how much of that was the integrity
+  // check. Recorded because the open is LAZY: without attributing it here it is
+  // charged to whichever background worker first touched the store, so an 80s
+  // quick_check reads as "durable_memory took 80s" and sends the next person
+  // reading the log to entirely the wrong file.
+  #rootRuntimeDbOpenMs: number | null = null;
+  #rootRuntimeDbIntegrityCheckMs: number | null = null;
 
   constructor(options: RuntimeStateStoreOptions = {}) {
     this.dbPath = hostStateDbPath(options);
@@ -1669,6 +1680,74 @@ export class RuntimeStateStore {
   supportsVectorIndex(): boolean {
     void this.db();
     return this.#vectorIndexSupported;
+  }
+
+  /**
+   * Timings for the root DB open, or nulls if it has not been opened in this
+   * process yet.
+   *
+   * Deliberately does NOT open the DB to answer — the caller is boot telemetry,
+   * and telemetry that triggers the expensive thing it is trying to measure is
+   * worse than no telemetry. A null here means "not opened", which is itself the
+   * honest answer.
+   */
+  rootRuntimeDbOpenTimings(): {
+    openMs: number | null;
+    integrityCheckMs: number | null;
+  } {
+    return {
+      openMs: this.#rootRuntimeDbOpenMs,
+      integrityCheckMs: this.#rootRuntimeDbIntegrityCheckMs,
+    };
+  }
+
+  /**
+   * Recent boot timings, as raw JSON, or null when the root DB is not already
+   * open in this process.
+   *
+   * Both this and its writer refuse to OPEN the DB, which is the whole point:
+   * the open is the expensive thing boot telemetry exists to measure, and a
+   * telemetry read that triggers an 80s integrity check would be strictly worse
+   * than having no telemetry at all. Losing a baseline is cheap; causing the
+   * failure you are measuring is not.
+   */
+  readBootTimingHistoryJson(): string | null {
+    const db = this.#rootRuntimeDb;
+    if (!db || !this.tableExists(db, "workspace_runtime_metadata")) {
+      return null;
+    }
+    try {
+      const row = db
+        .prepare<[string], { value?: string }>(
+          "SELECT value FROM workspace_runtime_metadata WHERE key = ? LIMIT 1",
+        )
+        .get(BOOT_TIMING_HISTORY_KEY);
+      return row?.value ?? null;
+    } catch {
+      // A telemetry read must never be the reason a boot fails.
+      return null;
+    }
+  }
+
+  /** Persist the boot-timing ring. No-ops (returning false) when the root DB is
+   *  not already open — see `readBootTimingHistoryJson`. */
+  writeBootTimingHistoryJson(json: string): boolean {
+    const db = this.#rootRuntimeDb;
+    if (!db || !this.tableExists(db, "workspace_runtime_metadata")) {
+      return false;
+    }
+    try {
+      db.prepare(`
+        INSERT INTO workspace_runtime_metadata (key, value, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+          value = excluded.value,
+          updated_at = excluded.updated_at
+      `).run(BOOT_TIMING_HISTORY_KEY, json, utcNowIso());
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -14041,6 +14120,7 @@ export class RuntimeStateStore {
         if (!this.rootDbPassesIntegrityCheck(db)) {
           throw new Error("root data.db failed quick_check");
         }
+        this.#rootRuntimeDbIntegrityCheckMs = Date.now() - startedAt;
         console.warn(
           `[state-store] integrity check passed in ${Math.round((Date.now() - startedAt) / 1000)}s`,
         );
@@ -14081,6 +14161,10 @@ export class RuntimeStateStore {
     if (this.#rootRuntimeDb) {
       return this.#rootRuntimeDb;
     }
+    // Times the WHOLE open, not just the connection: compaction, the integrity
+    // check, the vector extension, schema and migrations all land on the first
+    // caller, and any of them can be the slow one. Boot telemetry reads this.
+    const openStartedAt = Date.now();
     // One-time file compaction, if the background retention sweep requested it.
     // Runs here — before the connection is opened, while the DB is quiescent in
     // this single process — because that is the only point a VACUUM snapshot is
@@ -14101,6 +14185,7 @@ export class RuntimeStateStore {
     // `consolidateWorkspaceRuntimeDbsIntoRoot()` is retained (tests + that manual
     // recovery reference the same logic) but is never auto-invoked.
     this.#rootRuntimeDb = db;
+    this.#rootRuntimeDbOpenMs = Date.now() - openStartedAt;
     return db;
   }
 


### PR DESCRIPTION
Step 6, and the last of the boot work.

## What was missing

Steps 1–5 made boot survivable and observable — one integrity-check attempt (#507), the DB open off the bind path with phases on `/runtime/boot-status` (#508), a supervisor that tells advancing from stalled (#510), a bound on retention (#511). What none of them added was a **judgement**.

Every phase logs at INFO, so an 800ms boot and an 80s boot produce identical output, and the timings die with the process. That is exactly how 80s of `PRAGMA quick_check` went unnoticed until it bricked the app: the runtime was doing honest work the whole time and nothing anywhere said *this is not normal*.

## Three parts, each from something the livelock taught

**1. The alarm fires while the phase is still running.**
The boot that motivated all of this never finished — SIGKILLed mid-check on every attempt — so a check that runs at `ready` would have stayed silent for precisely the failure it was written for. A 1s watchdog polls the *in-flight* phase against its budget and warns once per phase. Verified against the real scenario:

```
budget for durable_memory: 30000ms
  at  1000ms over budget? false
  at 29000ms over budget? false
  at 31000ms over budget? true     <- fires here, mid-phase
  at 80000ms over budget? true
```

**2. The DB open is attributed to the DB open.**
`rootRuntimeDb()` is lazy, so the open — compaction, `quick_check`, vector extension, schema, migrations — is charged to whichever background worker touched the store first. An 80s check reads as `durable_memory took 80s`, which sends the next person to entirely the wrong file. The store now times the open and the check separately.

**3. "Slow" is machine-relative.**
A cold spinning disk and a warm SSD differ by more than an order of magnitude, so one absolute threshold either cries wolf on slow hardware or never fires on fast hardware. The last 10 boots persist to the root DB; a boot 3× the median is reported as a regression independently of the absolute budgets. Median, not mean, so one pathological boot cannot drag the baseline up and hide the next one. A 1s floor keeps a 40ms→200ms boot quiet.

On a completed 82s boot against a 4s baseline, all three reasons are reported rather than collapsed to `slow: true` — they point at different things (a subsystem vs. the data):

```
[phase_over_budget]    boot phase durable_memory took 80000ms (budget 30000ms)
[total_over_budget]    boot took 82000ms (budget 60000ms)
[slower_than_baseline] boot took 82000ms, 20.5x this machine's baseline of 4000ms
```

## Two rules the telemetry obeys, both tested

- **It never forces the root DB open.** The open is the expensive thing being measured; a telemetry read that triggered an 80s check would be strictly worse than no telemetry at all. Both accessors decline when the DB isn't already open, and the caller loses only its baseline. The test asserts no `data.db` is created.
- **It never fails a boot.** Parsing a history written by an older build cannot throw, and the record-and-classify block is guarded.

## Budgets

Set generously and per phase (`durable_memory` 30s because it wears the open, `channel_gateway` 20s because a slow network is not a broken boot, 5s default for phases added later). A false alarm every launch trains people to ignore the alarm, which costs more than the alarm was ever worth.

## Surfaces

`/runtime/boot-status` gains `phase_budget_ms`, `phase_over_budget` and `alarms`, so the supervisor and splash can tell slow from stuck without duplicating the budget table on the desktop side. The desktop mirrors the alarm into its own log — that is the log attached to "the app hung on launch", which is the report where knowing the phase *is* the diagnosis.

## Tests

- `boot-telemetry.test.ts` — 14 tests over the pure core: budgets, the mid-phase question, median-ignores-outlier, the regression floor, the bounded ring, and parsing that tolerates anything an older build wrote
- `boot-timing-history.test.ts` — 3 tests, including the never-opens-the-DB rule
- `app.test.ts` — 2 tests: the endpoint's new fields, and a healthy boot recording its timings with `root_db_open_ms` attributed

state-store 149 pass · api-server 1138 (1135 pass, 3 pre-existing skips) · desktop typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)