### PR TITLE
fix(release): stop packaging harness-host twice, and raise the open-file limit where it's used

### DIFF
--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -83,7 +83,63 @@ if (
   );
 }
 
-const child = spawn(process.execPath, [electronBuilderCli, ...builderArgs], {
+/**
+ * Raise the open-file limit for electron-builder itself.
+ *
+ * Signing walks every file in the app bundle, and the staged runtime is tens of
+ * thousands of files; on macOS the default soft limit is 256, and exceeding it
+ * fails the build with `EMFILE: too many open files` on whichever file happened
+ * to be next — a misleading error that looks like a problem with that file.
+ *
+ * The workflows already raise the limit, but they do it in the *prepare* step,
+ * and `ulimit` does not survive into a later `run:` block — each step gets a
+ * fresh shell, so the electron-builder step has always run at the default. It
+ * belongs here instead: this wrapper is the one chokepoint every invocation
+ * goes through (CI and local packaging alike), so the limit cannot drift away
+ * from the command that needs it.
+ *
+ * `ulimit` is a shell builtin and Node exposes no setrlimit, so raising it means
+ * going through a shell. `"$@"` keeps argv intact rather than re-quoting it, and
+ * a failure to raise is non-fatal — the build then behaves exactly as it does
+ * today rather than not running at all.
+ *
+ * It raises only, never lowers: developer machines are commonly configured well
+ * above this floor (1048576 is typical on macOS), and setting the limit
+ * unconditionally would *reduce* it on exactly the machines that needed no help.
+ */
+const OPEN_FILE_LIMIT = 65536;
+// Moves the SOFT limit only, clamped to the hard limit. `ulimit -n` without a
+// flag sets soft *and* hard, and lowering the hard limit is irreversible for a
+// non-root process — so a plain `ulimit -n` here could leave the build worse off
+// than it started. Raising the soft limit toward hard is always permitted.
+const RAISE_OPEN_FILE_LIMIT = [
+  `soft="$(ulimit -Sn)"`,
+  `hard="$(ulimit -Hn)"`,
+  `target=${OPEN_FILE_LIMIT}`,
+  `if [ "$hard" != "unlimited" ] && [ "$hard" -lt "$target" ] 2>/dev/null; then`,
+  `  target="$hard"`,
+  `fi`,
+  `if [ "$soft" != "unlimited" ] && [ "$soft" -lt "$target" ] 2>/dev/null; then`,
+  `  ulimit -Sn "$target" 2>/dev/null || true`,
+  `fi`,
+  `exec "$@"`
+].join("\n");
+const useShellLimit = process.platform !== "win32";
+const [command, commandArgs] = useShellLimit
+  ? [
+      "/bin/sh",
+      [
+        "-c",
+        RAISE_OPEN_FILE_LIMIT,
+        "sh",
+        process.execPath,
+        electronBuilderCli,
+        ...builderArgs
+      ]
+    ]
+  : [process.execPath, [electronBuilderCli, ...builderArgs]];
+
+const child = spawn(command, commandArgs, {
   cwd: desktopRoot,
   env: {
     ...process.env,

--- a/bun.lock
+++ b/bun.lock
@@ -406,7 +406,6 @@
         "@fastify/websocket": "^11.2.0",
         "@holaboss/remote-api": "workspace:*",
         "@holaboss/runtime-channel-gateway": "workspace:*",
-        "@holaboss/runtime-harness-host": "workspace:*",
         "@holaboss/runtime-state-store": "workspace:*",
         "@larksuiteoapi/node-sdk": "^1.67.0",
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/runtime/api-server/package.json
+++ b/runtime/api-server/package.json
@@ -25,7 +25,6 @@
     "@fastify/websocket": "^11.2.0",
     "@holaboss/remote-api": "workspace:*",
     "@holaboss/runtime-channel-gateway": "workspace:*",
-    "@holaboss/runtime-harness-host": "workspace:*",
     "@holaboss/runtime-state-store": "workspace:*",
     "@larksuiteoapi/node-sdk": "^1.67.0",
     "@modelcontextprotocol/sdk": "^1.28.0",

--- a/runtime/api-server/src/harness-in-process-boundary.test.ts
+++ b/runtime/api-server/src/harness-in-process-boundary.test.ts
@@ -70,15 +70,17 @@ test("harness-host still exports the in-process contract ts-runner casts to", as
   const module = (await import(entry)) as {
     runPiInProcess?: (params: Record<string, unknown>) => Promise<unknown>;
   };
+  const runPiInProcess = module.runPiInProcess;
   assert.equal(
-    typeof module.runPiInProcess,
+    typeof runPiInProcess,
     "function",
     "ts-runner destructures runPiInProcess from this module",
   );
+  assert.ok(runPiInProcess);
 
   // Drive it with a stubbed pi, then assert every field ts-runner reads off the
   // result is actually present — the fields, not just the function name.
-  const result = (await module.runPiInProcess({
+  const result = (await runPiInProcess({
     requestPayload: { session_id: "s", input_id: "i" },
     emitEvent: async () => {},
     deps: {

--- a/runtime/api-server/src/harness-in-process-boundary.test.ts
+++ b/runtime/api-server/src/harness-in-process-boundary.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * The api-server ↔ harness-host boundary, pinned from the api-server side.
+ *
+ * ts-runner runs pi in-process by importing harness-host's built entry point
+ * BY PATH and casting the result to a locally-declared interface. That cast is
+ * necessary — declaring the package as a dependency is what caused the failure
+ * below — but it also means TypeScript can no longer check that the two sides
+ * agree. These tests are what replaces that lost checking.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const apiServerRoot = path.resolve(here, "..");
+const runtimeRoot = path.resolve(apiServerRoot, "..");
+
+test("api-server must not depend on harness-host", () => {
+  // Declaring this dependency made bun copy harness-host's entire tree into
+  // api-server/node_modules during runtime staging — a 14,734-file / 473MB
+  // duplicate of a package already staged as a sibling. It doubled the packaged
+  // file count and broke the signed macOS release with EMFILE, electron-builder
+  // exhausting its file descriptors partway through signing.
+  //
+  // The dependency also runs the wrong way round: harness-host is downstream of
+  // api-server's contracts, not upstream of them.
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(apiServerRoot, "package.json"), "utf8"),
+  ) as Record<string, Record<string, string> | undefined>;
+
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    assert.equal(
+      manifest[field]?.["@holaboss/runtime-harness-host"],
+      undefined,
+      `@holaboss/runtime-harness-host must not be in ${field} — it is staged as a sibling and duplicating it broke the macOS release with EMFILE`,
+    );
+  }
+});
+
+test("the staging rewrite table does not reintroduce the duplicate", () => {
+  // The rewrite table is what turns `workspace:*` into a real install during
+  // runtime staging, so an entry here recreates the duplication even if
+  // package.json is clean.
+  const staging = fs.readFileSync(
+    path.join(runtimeRoot, "deploy", "build_runtime_root.mjs"),
+    "utf8",
+  );
+  const rewrites = staging.slice(
+    staging.indexOf("WORKSPACE_SIBLING_REWRITES"),
+    staging.indexOf("WORKSPACE_SIBLING_REWRITES") + 2000,
+  );
+  assert.ok(
+    !rewrites.includes("@holaboss/runtime-harness-host"),
+    "harness-host must not be rewritten into api-server's install",
+  );
+});
+
+test("harness-host still exports the in-process contract ts-runner casts to", async () => {
+  // ts-runner declares this shape locally (HarnessHostInProcessModule) and casts
+  // the dynamic import to it. If harness-host renames the export or a result
+  // field, the cast keeps compiling and the failure only shows up at runtime as
+  // a turn that silently falls back to spawning — losing the whole in-process
+  // win with nothing but a warning to say so. This asserts the two agree.
+  const entry = path.join(runtimeRoot, "harness-host", "src", "index.ts");
+  assert.ok(fs.existsSync(entry), `harness-host entry missing at ${entry}`);
+
+  const module = (await import(entry)) as {
+    runPiInProcess?: (params: Record<string, unknown>) => Promise<unknown>;
+  };
+  assert.equal(
+    typeof module.runPiInProcess,
+    "function",
+    "ts-runner destructures runPiInProcess from this module",
+  );
+
+  // Drive it with a stubbed pi, then assert every field ts-runner reads off the
+  // result is actually present — the fields, not just the function name.
+  const result = (await module.runPiInProcess({
+    requestPayload: { session_id: "s", input_id: "i" },
+    emitEvent: async () => {},
+    deps: {
+      runPi: async (
+        request: unknown,
+        deps: {
+          emitEvent?: (
+            request: unknown,
+            sequence: number,
+            eventType: string,
+            payload: Record<string, unknown>,
+          ) => void;
+        },
+      ) => {
+        deps.emitEvent?.(request, 1, "output_delta", {});
+        deps.emitEvent?.(request, 2, "run_completed", {});
+        return 0;
+      },
+      defaultPiDeps: () => ({}),
+    },
+  })) as Record<string, unknown>;
+
+  for (const field of [
+    "exitCode",
+    "stderr",
+    "sawEvent",
+    "terminalEmitted",
+    "lastSequence",
+    "harnessSpawnToFirstEventMs",
+    "harnessSpawnToFirstTokenMs",
+  ]) {
+    assert.ok(
+      field in result,
+      `ts-runner reads result.${field}; harness-host no longer returns it`,
+    );
+  }
+  assert.equal(result.terminalEmitted, true);
+  assert.equal(result.exitCode, 0);
+});

--- a/runtime/api-server/src/ts-runner.ts
+++ b/runtime/api-server/src/ts-runner.ts
@@ -1913,7 +1913,23 @@ const inProcessRunHarnessHost: TsRunnerExecutionDeps["runHarnessHost"] = async (
   installInProcessTerminationGuard(logger);
   inProcessTurnsActive += 1;
   try {
-    const { runPiInProcess } = await import("@holaboss/runtime-harness-host");
+    // Imported by PATH from the sibling harness-host build — the exact file the
+    // spawn path would have executed — rather than as a package dependency.
+    //
+    // Declaring the dependency made bun copy harness-host's whole tree into
+    // api-server/node_modules during runtime staging: a second 473MB / 14,734
+    // file copy of something already staged as a sibling. That bloated the app
+    // bundle and broke the signed macOS release with EMFILE, electron-builder
+    // running out of file descriptors while signing.
+    //
+    // Resolving by path also strengthens Blocker 0's guarantee instead of
+    // merely satisfying it: there is now provably ONE harness-host build, so
+    // the in-process path cannot drift from the spawned one or pick up an
+    // unpatched copy of pi.
+    const { entryPath } = harnessHostEntryPath();
+    const { runPiInProcess } = (await import(
+      pathToFileURL(entryPath).href
+    )) as HarnessHostInProcessModule;
     const result = await runPiInProcess({
       requestPayload: params.requestPayload,
       emitEvent: async (event) => {
@@ -1944,6 +1960,46 @@ const inProcessRunHarnessHost: TsRunnerExecutionDeps["runHarnessHost"] = async (
     inProcessTurnsActive = Math.max(0, inProcessTurnsActive - 1);
   }
 };
+
+/**
+ * The slice of harness-host's in-process entry point this module calls.
+ *
+ * Declared structurally rather than imported as
+ * `typeof import("@holaboss/runtime-harness-host")`, because that import is a
+ * real resolution even though it is type-only: it needs the package present in
+ * api-server's node_modules, which is exactly the duplication being removed
+ * above. The staged build catches this where the dev workspace does not — the
+ * workspace symlink makes it resolve locally, and it fails only in packaging.
+ *
+ * The duplication runs the same direction as `TERMINAL_EVENT_TYPES` in
+ * harness-host's in-process.ts: a small contract copied across the boundary
+ * rather than a dependency edge, because api-server must not depend on
+ * harness-host (the dependency runs the other way).
+ */
+interface HarnessHostInProcessModule {
+  runPiInProcess(params: {
+    requestPayload: unknown;
+    emitEvent: (event: {
+      session_id: string;
+      input_id: string;
+      sequence: number;
+      event_type: string;
+      timestamp: string;
+      payload: Record<string, unknown>;
+    }) => Promise<void>;
+    firstEventTimeoutMs?: number;
+    logger?: LoggerLike;
+  }): Promise<{
+    exitCode: number;
+    stderr: string;
+    sawEvent: boolean;
+    terminalEmitted: boolean;
+    lastSequence: number;
+    harnessSpawnToFirstEventMs?: number;
+    harnessSpawnToFirstTokenMs?: number;
+    postTerminalError?: string | null;
+  }>;
+}
 
 function harnessHostEntryPath(): { entryPath: string; argsPrefix: string[] } {
   const currentFile = fileURLToPath(import.meta.url);

--- a/runtime/deploy/build_runtime_root.mjs
+++ b/runtime/deploy/build_runtime_root.mjs
@@ -162,10 +162,6 @@ const WORKSPACE_SIBLING_REWRITES = {
   "@holaboss/runtime-state-store": "file:../state-store",
   "@holaboss/remote-api": "file:../remote-api",
   "@holaboss/runtime-channel-gateway": "file:../channel-gateway",
-  // api-server calls into harness-host for the in-process pi path
-  // (HB_HARNESS_IN_PROCESS). harness-host is staged above api-server, so the
-  // sibling dir exists by the time api-server's install runs.
-  "@holaboss/runtime-harness-host": "file:../harness-host",
 };
 
 // Postinstall lifecycle scripts only run for packages listed here


### PR DESCRIPTION
The macOS release fails with `EMFILE: too many open files` while signing, on a path inside `api-server/node_modules`. Two independent causes, both fixed here.

## 1. The duplication (mine)

Wiring the in-process pi path (`14918ae`) declared `@holaboss/runtime-harness-host` as an api-server dependency, so runtime staging installed a **full copy of harness-host inside api-server** — on top of the copy already staged as a sibling.

Measured on the staged tree:

| | before | after |
|---|---|---|
| staged `api-server` | 35,922 files / 1.0G | **17,279 files / 183M** |
| nested `@holaboss/runtime-harness-host` | 14,734 files / 473M | gone |

ts-runner now imports the sibling **by path** — the exact file the spawn path would have executed. That also strengthens the guarantee the dependency was only satisfying by accident: there is provably one harness-host build, so the in-process path can't drift from the spawned one or pick up an unpatched copy of pi.

## 2. The limit (pre-existing)

Both workflows already raise `ulimit -n` — but in the **prepare** step. `ulimit` doesn't survive into a later `run:` block, so the electron-builder step has always run at the default. Moved into `run-electron-builder.mjs`, the one chokepoint every invocation goes through.

It raises the **soft** limit only, clamped to hard — plain `ulimit -n` sets both, and lowering the hard limit is irreversible for a non-root process. Verified:

- soft 256 → raised to 65536 (the CI case)
- soft 1048576 → left alone (an unconditional set would have **lowered** it)
- argv preserved through the shell, including args containing spaces

## Confidence

There's no green release run to compare against, so the duplication is **strongly indicated rather than proven** to be the sole cause — the failing path sits inside the tree that shrank. The limit fix is the standard remedy and holds either way.

## Testing

The type-only `typeof import(...)` had to go as well: it's a real resolution that kept the dependency alive, and the staged build catches it where the dev workspace doesn't (the workspace symlink makes it resolve locally; it fails only in packaging). ts-runner declares the contract structurally instead, which costs the type-checking across that boundary — so a new test pins what the cast no longer can:

- the dependency stays absent from every manifest field
- the staging rewrite table doesn't reintroduce it
- harness-host still exports `runPiInProcess` with every result field ts-runner reads

Runtime staging now completes green; api-server 1149 pass / 0 fail, harness-host 298 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)