### PR TITLE
test(runtime): cover resume, SIGTERM deferral and compaction automatically

### DIFF
--- a/runtime/api-server/src/in-process-termination.test.ts
+++ b/runtime/api-server/src/in-process-termination.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * SIGTERM deferral for in-process pi turns.
+ *
+ * Why this needs a real child: runner-worker SIGTERMs the runner the moment it
+ * sees a terminal event, and with pi in-process that signal lands while pi is
+ * still doing its post-terminal work — compaction and dispose run AFTER
+ * `run_completed`. If the signal killed the runner there, compaction would be
+ * cut off halfway and the next turn would resume an uncompacted session.
+ *
+ * That is a property of process-global signal disposition, so it cannot be
+ * asserted in-process: a test that installs the handler in the test runner
+ * would either kill the runner or prove nothing. Each case below therefore
+ * stages the turn in a child and sends it a genuine signal.
+ *
+ * This path runs on EVERY turn, not just at shutdown — which is what makes it
+ * worth the cost of a subprocess test.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CHILD = path.join(here, "testing", "in-process-signal-child.mts");
+
+interface Child {
+  process: ChildProcess;
+  ready: Promise<void>;
+  settled: Promise<void>;
+  exited: Promise<{ code: number | null; signal: string | null }>;
+  stderr: () => string;
+}
+
+function startChild(scenario: "settle" | "wedge", graceMs: number): Child {
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", CHILD, scenario],
+    {
+      cwd: path.resolve(here, ".."),
+      env: {
+        ...process.env,
+        HB_HARNESS_IN_PROCESS_GRACE_MS: String(graceMs),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const waiters = new Map<string, () => void>();
+  const signal = (key: string) =>
+    new Promise<void>((resolve) => waiters.set(key, resolve));
+  const ready = signal("ready");
+  const settled = signal("settled");
+
+  let buffer = "";
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    buffer += chunk;
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      const message = JSON.parse(line) as Record<string, unknown>;
+      for (const [key, resolve] of waiters) {
+        if (message[key] === true) {
+          resolve();
+        }
+      }
+    }
+  });
+
+  const exited = new Promise<{ code: number | null; signal: string | null }>(
+    (resolve) => {
+      child.on("exit", (code, exitSignal) => {
+        resolve({ code, signal: exitSignal });
+      });
+    },
+  );
+
+  return { process: child, ready, settled, exited, stderr: () => stderr };
+}
+
+/** Resolves to null if the process is still running when the window elapses. */
+async function exitWithin(
+  child: Child,
+  ms: number,
+): Promise<{ code: number | null; signal: string | null } | null> {
+  return await Promise.race([
+    child.exited,
+    new Promise<null>((resolve) => {
+      setTimeout(() => resolve(null), ms).unref?.();
+    }),
+  ]);
+}
+
+test("SIGTERM during an in-flight turn does not kill the runner", async () => {
+  // The turn here stands in for pi's post-terminal window: run_completed has
+  // been relayed, runner-worker has fired SIGTERM, and compaction is still
+  // running. Dying now truncates it.
+  const child = startChild("settle", 30_000);
+  try {
+    await child.ready;
+    child.process.kill("SIGTERM");
+
+    const early = await exitWithin(child, 400);
+    assert.equal(
+      early,
+      null,
+      "the runner exited while a turn was still in flight — post-terminal compaction would be cut off",
+    );
+    assert.match(
+      child.stderr(),
+      /deferring SIGTERM/,
+      "the deferral should say so; a silent one is indistinguishable from a missing handler",
+    );
+
+    child.process.stdin?.write("settle\n");
+    await child.settled;
+
+    // The deferral must RELEASE when the turn ends, not grant the runner
+    // lasting immunity to signals. A counter that failed to unwind — an early
+    // return that skipped `endInProcessTurn`, say — would leave the runner
+    // killable only by SIGKILL, and the symptom would be orphaned runner
+    // processes rather than anything visible in a turn.
+    child.process.kill("SIGTERM");
+    const after = await exitWithin(child, 5_000);
+    assert.notEqual(
+      after,
+      null,
+      "a signal after the turn settled must terminate the runner immediately",
+    );
+    assert.equal(after?.code, 0);
+  } finally {
+    child.process.kill("SIGKILL");
+  }
+});
+
+test("SIGINT is deferred the same way as SIGTERM", async () => {
+  const child = startChild("settle", 30_000);
+  try {
+    await child.ready;
+    child.process.kill("SIGINT");
+    assert.equal(
+      await exitWithin(child, 400),
+      null,
+      "SIGINT must defer too — the default disposition kills the process outright",
+    );
+  } finally {
+    child.process.kill("SIGKILL");
+  }
+});
+
+test("a turn that never settles still exits, via the grace timer", async () => {
+  // The deferral must be bounded. Without the timer a wedged turn would hold
+  // the runner open indefinitely and the parent would have to SIGKILL it.
+  const child = startChild("wedge", 300);
+  try {
+    await child.ready;
+    child.process.kill("SIGTERM");
+
+    const result = await exitWithin(child, 8_000);
+    assert.notEqual(result, null, "the grace timer did not fire");
+    assert.equal(result?.code, 0, "the bounded exit should be clean");
+    assert.match(
+      child.stderr(),
+      /did not settle within 300ms/,
+      "the forced exit should be attributable in the log",
+    );
+  } finally {
+    child.process.kill("SIGKILL");
+  }
+});
+
+test("repeated signals during one turn do not stack grace timers", async () => {
+  // runner-worker can fire more than once (terminal event, then stream
+  // teardown). Each signal starting its own timer would make the effective
+  // grace the FIRST one to fire, shortening the window unpredictably.
+  const child = startChild("settle", 30_000);
+  try {
+    await child.ready;
+    for (let i = 0; i < 5; i += 1) {
+      child.process.kill("SIGTERM");
+    }
+    assert.equal(await exitWithin(child, 400), null, "still deferring");
+
+    const deferrals = child.stderr().match(/deferring SIG/g) ?? [];
+    assert.equal(
+      deferrals.length,
+      1,
+      `expected one deferral for five signals, got ${deferrals.length}`,
+    );
+  } finally {
+    child.process.kill("SIGKILL");
+  }
+});

--- a/runtime/api-server/src/resume-round-trip.test.ts
+++ b/runtime/api-server/src/resume-round-trip.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  relayTsRunnerEvent,
+  resolveTsRunnerBootstrapState,
+} from "./ts-runner.js";
+
+/**
+ * Resume, end to end across two turns.
+ *
+ * Both halves are already covered on their own: that a terminal event persists
+ * its `harness_session_id`, and that bootstrap can load a persisted id. What was
+ * not covered is that they meet — that the id turn 1 WRITES is the id turn 2
+ * READS. The write goes to `.holaboss/state/harness-session-state.json` (v2) and
+ * the read also accepts a legacy `.holaboss/harness-session-state.json` (v1), so
+ * the two sides address the same fact through different paths and formats. Each
+ * half can stay green while the seam between them silently stops working.
+ *
+ * When it does stop working the symptom is not an error: every turn simply
+ * starts a fresh pi session, and the agent quietly forgets the conversation.
+ * That is why this was previously checked by hand — by sending several messages
+ * and looking at whether one session file grew.
+ */
+
+function turnWorkspace(prefix: string): {
+  sandboxRoot: string;
+  workspaceId: string;
+  workspaceDir: string;
+} {
+  const sandboxRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const workspaceId = "workspace-1";
+  const workspaceDir = path.join(sandboxRoot, "workspace", workspaceId);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  return { sandboxRoot, workspaceId, workspaceDir };
+}
+
+/** The bootstrap turn N performs: what session, if any, does it resume? */
+function bootstrapForTurn(workspaceId: string, inputId: string) {
+  return resolveTsRunnerBootstrapState({
+    workspace_id: workspaceId,
+    session_id: "session-1",
+    input_id: inputId,
+    instruction: "hello",
+    context: { _sandbox_runtime_exec_v1: { harness: "pi" } },
+    model: null,
+    debug: false,
+  });
+}
+
+/** The terminal event that ends a turn, carrying the id to resume from. */
+async function completeTurn(params: {
+  workspaceDir: string;
+  inputId: string;
+  harnessSessionId: string;
+  status?: "success" | "failed";
+}): Promise<void> {
+  const failed = params.status === "failed";
+  await relayTsRunnerEvent({
+    harness: "pi",
+    workspaceDir: params.workspaceDir,
+    event: {
+      session_id: "session-1",
+      input_id: params.inputId,
+      sequence: 4,
+      event_type: failed ? "run_failed" : "run_completed",
+      timestamp: new Date().toISOString(),
+      payload: {
+        status: failed ? "failed" : "success",
+        harness_session_id: params.harnessSessionId,
+      },
+    },
+    emitEvent: async () => {},
+  });
+}
+
+test("turn 2 resumes the session turn 1 persisted", async (t) => {
+  const previousRoot = process.env.HB_SANDBOX_ROOT;
+  t.after(() => {
+    process.env.HB_SANDBOX_ROOT = previousRoot;
+  });
+  const { sandboxRoot, workspaceId, workspaceDir } = turnWorkspace(
+    "hb-resume-round-trip-",
+  );
+  process.env.HB_SANDBOX_ROOT = sandboxRoot;
+
+  // Turn 1 starts with nothing to resume — the first turn of a conversation.
+  assert.equal(
+    bootstrapForTurn(workspaceId, "input-1").persistedHarnessSessionId,
+    null,
+    "a fresh workspace must not resume anything",
+  );
+
+  await completeTurn({
+    workspaceDir,
+    inputId: "input-1",
+    harnessSessionId: "pi-session-abc",
+  });
+
+  // Turn 2 must pick it up. This is the assertion the manual check was making.
+  const secondTurn = bootstrapForTurn(workspaceId, "input-2");
+  assert.equal(
+    secondTurn.persistedHarnessSessionId,
+    "pi-session-abc",
+    "turn 2 did not resume turn 1's session — the agent would silently forget the conversation",
+  );
+  assert.equal(secondTurn.workspaceDir, workspaceDir);
+  assert.equal(secondTurn.harness, "pi");
+});
+
+test("the resumed id stays stable across a run of turns", async (t) => {
+  const previousRoot = process.env.HB_SANDBOX_ROOT;
+  t.after(() => {
+    process.env.HB_SANDBOX_ROOT = previousRoot;
+  });
+  const { sandboxRoot, workspaceId, workspaceDir } = turnWorkspace(
+    "hb-resume-stable-",
+  );
+  process.env.HB_SANDBOX_ROOT = sandboxRoot;
+
+  // pi returns the same session id every turn once a session exists; the
+  // runtime must keep converging on it rather than accumulating or rotating.
+  for (let turn = 1; turn <= 4; turn += 1) {
+    const bootstrap = bootstrapForTurn(workspaceId, `input-${turn}`);
+    assert.equal(
+      bootstrap.persistedHarnessSessionId,
+      turn === 1 ? null : "pi-session-abc",
+      `turn ${turn} resumed the wrong session`,
+    );
+    await completeTurn({
+      workspaceDir,
+      inputId: `input-${turn}`,
+      harnessSessionId: "pi-session-abc",
+    });
+  }
+});
+
+test("a failed turn clears the pointer so the next turn starts clean", async (t) => {
+  const previousRoot = process.env.HB_SANDBOX_ROOT;
+  t.after(() => {
+    process.env.HB_SANDBOX_ROOT = previousRoot;
+  });
+  const { sandboxRoot, workspaceId, workspaceDir } = turnWorkspace(
+    "hb-resume-failed-",
+  );
+  process.env.HB_SANDBOX_ROOT = sandboxRoot;
+
+  await completeTurn({
+    workspaceDir,
+    inputId: "input-1",
+    harnessSessionId: "pi-session-abc",
+  });
+  assert.equal(
+    bootstrapForTurn(workspaceId, "input-2").persistedHarnessSessionId,
+    "pi-session-abc",
+  );
+
+  // This is the direction that matters for the in-process path: a run reported
+  // as FAILED clears the pointer. It is why a post-terminal error (compaction
+  // throwing after run_completed) must never be reported as a failed run — the
+  // turn succeeded, but relaying a failure here would discard the conversation.
+  await completeTurn({
+    workspaceDir,
+    inputId: "input-2",
+    harnessSessionId: "pi-session-abc",
+    status: "failed",
+  });
+
+  assert.equal(
+    bootstrapForTurn(workspaceId, "input-3").persistedHarnessSessionId,
+    null,
+    "a failed run must clear the resume pointer",
+  );
+});

--- a/runtime/api-server/src/testing/in-process-signal-child.mts
+++ b/runtime/api-server/src/testing/in-process-signal-child.mts
@@ -1,0 +1,60 @@
+/**
+ * Child process for `in-process-termination.test.ts`.
+ *
+ * Signal disposition is process-global: whether a SIGTERM kills the runner
+ * mid-turn cannot be asserted from inside the process that owns the handler.
+ * So the behaviour is staged in a real child, driven over stdout/stdin.
+ *
+ * Protocol (one JSON object per line on stdout):
+ *   {"ready":true}    guard installed, turn in flight
+ *   {"settled":true}  the turn finished
+ * stdin: "settle\n" ends the turn.
+ *
+ * argv[2] selects the scenario:
+ *   settle  the turn ends after the signal — the real shape of every turn
+ *   wedge   the turn never ends — the grace timer must force the exit
+ */
+import { beginInProcessTurn, endInProcessTurn } from "../ts-runner.js";
+
+const scenario = process.argv[2] ?? "settle";
+const say = (value: unknown): void => {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+};
+
+// Hold the event loop open for the whole test. Without this the process would
+// exit on its own the moment it went idle, and "exited because the loop
+// drained" is indistinguishable from "exited because the signal killed us" —
+// the test would pass whether or not the deferral worked. In production the
+// loop is held by the runtime's own open handles.
+const keepAlive = setInterval(() => {}, 1_000);
+
+const logger = {
+  warn: (message: string) => {
+    process.stderr.write(`${message}\n`);
+  },
+  error: (message: string) => {
+    process.stderr.write(`${message}\n`);
+  },
+  log: () => {},
+  info: () => {},
+  debug: () => {},
+};
+
+beginInProcessTurn(logger as never);
+say({ ready: true });
+
+if (scenario === "settle") {
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk: string) => {
+    if (!chunk.includes("settle")) {
+      return;
+    }
+    endInProcessTurn(logger as never);
+    say({ settled: true });
+    // Release the loop, exactly as the runner does once its post-run work is
+    // done. A correctly deferred termination lets the process leave here.
+    clearInterval(keepAlive);
+    process.stdin.pause();
+  });
+}
+// scenario === "wedge": the turn never ends, so only the grace timer can exit.

--- a/runtime/api-server/src/ts-runner.ts
+++ b/runtime/api-server/src/ts-runner.ts
@@ -1826,6 +1826,32 @@ let inProcessTurnsActive = 0;
 let inProcessTerminationDeferred = false;
 let inProcessSignalGuardInstalled = false;
 
+/**
+ * Exported for tests. Signal disposition is process-global and cannot be
+ * observed from inside the process that owns it — asserting "this SIGTERM did
+ * not kill us" requires a real child receiving a real signal — so the seam has
+ * to be reachable from outside this module. `beginInProcessTurn` /
+ * `endInProcessTurn` are how the counter is maintained in production too, so
+ * tests drive the same path rather than a parallel one.
+ */
+export function beginInProcessTurn(logger: LoggerLike): void {
+  installInProcessTerminationGuard(logger);
+  inProcessTurnsActive += 1;
+}
+
+export function endInProcessTurn(_logger: LoggerLike): void {
+  inProcessTurnsActive = Math.max(0, inProcessTurnsActive - 1);
+  // Deliberately does NOT exit on the deferred signal, tempting as that looks.
+  // This runs in a `finally` inside the harness call, and the runner still has
+  // its own post-run work to do afterwards — exiting here would truncate the
+  // very persistence resume depends on, which is the failure the deferral
+  // exists to prevent in the first place.
+  //
+  // Once the turn settles the process exits by draining its event loop, which
+  // is both prompt and safe. The grace timer remains the backstop for the case
+  // where something keeps the loop alive.
+}
+
 function installInProcessTerminationGuard(logger: LoggerLike): void {
   if (inProcessSignalGuardInstalled) {
     return;
@@ -1910,8 +1936,7 @@ const inProcessRunHarnessHost: TsRunnerExecutionDeps["runHarnessHost"] = async (
   }
   logger.warn("harness in-process: running pi in ts-runner (no second spawn)");
   const startedAtMs = Date.now();
-  installInProcessTerminationGuard(logger);
-  inProcessTurnsActive += 1;
+  beginInProcessTurn(logger);
   try {
     // Imported by PATH from the sibling harness-host build — the exact file the
     // spawn path would have executed — rather than as a package dependency.
@@ -1957,7 +1982,7 @@ const inProcessRunHarnessHost: TsRunnerExecutionDeps["runHarnessHost"] = async (
     );
     return await defaultRunHarnessHost(params);
   } finally {
-    inProcessTurnsActive = Math.max(0, inProcessTurnsActive - 1);
+    endInProcessTurn(logger);
   }
 };
 

--- a/runtime/harness-host/src/compaction-threshold.test.ts
+++ b/runtime/harness-host/src/compaction-threshold.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  compactSessionOverThreshold,
+  piCompactionReserveTokens,
+} from "./pi.js";
+
+/**
+ * End-of-turn compaction, driven directly instead of by chatting until the
+ * context window fills up.
+ *
+ * This was previously verifiable only by hand: the trigger lived in a closure
+ * over a live session, so reaching it meant a real conversation long enough to
+ * cross half the context window, and the outcome was written to a `console.warn`
+ * that lands in ts-runner's buffered stderr — surfaced only when a run FAILS.
+ * Compaction failing does not fail the run, so the one signal that it broke went
+ * to a stream nobody reads.
+ */
+
+/** Minimal stand-in for pi's AgentSession: only the surface compaction uses. */
+function fakeSession(options: {
+  tokens?: number | null;
+  contextWindow?: number;
+  isCompacting?: boolean;
+  compact?: () => Promise<unknown>;
+  omitCompact?: boolean;
+}) {
+  const calls: string[] = [];
+  const session: Record<string, unknown> = {
+    isCompacting: options.isCompacting ?? false,
+    getContextUsage: () =>
+      options.contextWindow === undefined && options.tokens === undefined
+        ? null
+        : { tokens: options.tokens ?? null, contextWindow: options.contextWindow ?? 0 },
+  };
+  if (!options.omitCompact) {
+    session.compact = async () => {
+      calls.push("compact");
+      return options.compact ? await options.compact() : undefined;
+    };
+  }
+  return { session, calls };
+}
+
+test("compaction fires once usage crosses half the context window", async () => {
+  // The threshold is `contextWindow - reserve`, and reserve is defined so that
+  // the trigger sits at 50% of the window. Pinning it here means a change to
+  // the ratio has to be deliberate rather than incidental.
+  const contextWindow = 200_000;
+  const threshold = contextWindow - piCompactionReserveTokens(contextWindow);
+  assert.equal(threshold, 100_000, "trigger should be half the context window");
+
+  const under = fakeSession({ tokens: threshold, contextWindow });
+  assert.deepEqual(await compactSessionOverThreshold(under.session), {
+    status: "skipped",
+    reason: "under-threshold",
+  });
+  assert.deepEqual(under.calls, [], "exactly at the threshold must not compact");
+
+  const over = fakeSession({ tokens: threshold + 1, contextWindow });
+  assert.deepEqual(await compactSessionOverThreshold(over.session), {
+    status: "compacted",
+  });
+  assert.deepEqual(over.calls, ["compact"], "one token over must compact");
+});
+
+test("a compaction failure is reported, not swallowed", async () => {
+  // The failure that matters: the next turn resumes an uncompacted session and
+  // blows the context window. Previously this produced one console.warn into a
+  // buffered stream, so the user's symptom was an unexplained failure a turn later.
+  const { session } = fakeSession({
+    tokens: 150_000,
+    contextWindow: 200_000,
+    compact: async () => {
+      throw new Error("413 payload too large");
+    },
+  });
+
+  const outcome = await compactSessionOverThreshold(session);
+  assert.equal(outcome.status, "failed");
+  assert.match(
+    outcome.status === "failed" ? outcome.error : "",
+    /413 payload too large/,
+  );
+});
+
+test("compaction does not re-enter while pi is already compacting", async () => {
+  const { session, calls } = fakeSession({
+    tokens: 150_000,
+    contextWindow: 200_000,
+    isCompacting: true,
+  });
+  assert.deepEqual(await compactSessionOverThreshold(session), {
+    status: "skipped",
+    reason: "already-compacting",
+  });
+  assert.deepEqual(calls, []);
+});
+
+test("missing or unusable usage never triggers compaction", async () => {
+  // getContextUsage returning null, or a zero window, must be a skip rather than
+  // a divide-by-zero that compacts every turn.
+  for (const options of [
+    {},
+    { tokens: null, contextWindow: 200_000 },
+    { tokens: 150_000, contextWindow: 0 },
+  ]) {
+    const { session, calls } = fakeSession(options);
+    const outcome = await compactSessionOverThreshold(session);
+    assert.equal(
+      outcome.status,
+      "skipped",
+      `expected a skip for ${JSON.stringify(options)}`,
+    );
+    assert.deepEqual(calls, []);
+  }
+});
+
+test("a session without compact() is skipped rather than crashing the turn", async () => {
+  // Compaction runs AFTER the terminal event. A throw here is a post-terminal
+  // error, which the in-process path must not report as a failed run.
+  const { session } = fakeSession({
+    tokens: 150_000,
+    contextWindow: 200_000,
+    omitCompact: true,
+  });
+  assert.deepEqual(await compactSessionOverThreshold(session), {
+    status: "skipped",
+    reason: "unsupported",
+  });
+});

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -2807,6 +2807,78 @@ export function requestedPiThinkingConfig(
   return requestedHarnessThinkingConfig(request);
 }
 
+/** Why a compaction attempt did or did not happen. Returned rather than logged
+ *  so the decision is assertable: every one of these branches is a silent
+ *  no-op in production, and "compaction never ran" and "compaction ran and
+ *  failed" look identical from outside. */
+export type CompactionOutcome =
+  | { status: "compacted" }
+  | { status: "failed"; error: string }
+  | {
+      status: "skipped";
+      reason:
+        | "unsupported"
+        | "already-compacting"
+        | "usage-unavailable"
+        | "under-threshold";
+    };
+
+type CompactableSession = {
+  getContextUsage?: () => { tokens?: number | null; contextWindow?: number } | null;
+  compact?: (customInstructions?: string) => Promise<unknown>;
+  isCompacting?: boolean;
+};
+
+/**
+ * End-of-turn compaction: summarize the session once it crosses
+ * `PI_COMPACTION_USAGE_THRESHOLD_RATIO` of the model's context window.
+ *
+ * Extracted from `runPi` so it can be driven directly. In place it was a
+ * closure over a live `AgentSession`, reachable only by running a real model
+ * turn long enough to cross the threshold — which is why it had never been
+ * exercised except by hand, and why a failure here was invisible: the catch
+ * wrote to `console.warn`, and in-process that lands in ts-runner's stderr,
+ * which is buffered and surfaced only when a run FAILS. A compaction failure
+ * does not fail the run, so the warning was written to a stream nobody reads.
+ *
+ * The caller still logs; what changed is that the outcome is now a value, so
+ * both "did it run" and "did it work" can be asserted.
+ */
+export async function compactSessionOverThreshold(
+  rawSession: unknown,
+): Promise<CompactionOutcome> {
+  const session = rawSession as CompactableSession;
+  if (typeof session?.compact !== "function") {
+    return { status: "skipped", reason: "unsupported" };
+  }
+  if (session.isCompacting) {
+    return { status: "skipped", reason: "already-compacting" };
+  }
+  const usage = session.getContextUsage?.();
+  const tokens = typeof usage?.tokens === "number" ? usage.tokens : null;
+  const contextWindow =
+    typeof usage?.contextWindow === "number" ? usage.contextWindow : 0;
+  if (tokens === null || contextWindow <= 0) {
+    return { status: "skipped", reason: "usage-unavailable" };
+  }
+  if (tokens <= contextWindow - piCompactionReserveTokens(contextWindow)) {
+    return { status: "skipped", reason: "under-threshold" };
+  }
+  try {
+    // Compaction sends the full history to be summarized, so an image-bloated
+    // transcript would 413 the compaction request just like the turn did. Prune
+    // oversized inline images first so the summary request stays sendable.
+    capSessionImageContext(session);
+    await session.compact();
+    return { status: "compacted" };
+  } catch (error) {
+    return {
+      status: "failed",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export function piCompactionReserveTokens(contextWindow: number): number {
   if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
     return 0;
@@ -3981,33 +4053,10 @@ export async function runPi(request: HarnessHostPiRequest, deps: PiDeps = defaul
   // (`tokens > contextWindow - reserveTokens`). Best-effort: a compaction failure
   // must never fail the turn (pi emits its own compaction_end diagnostics).
   const maybeCompactSessionOverThreshold = async (): Promise<void> => {
-    const session = handle.session as AgentSession & {
-      getContextUsage?: () => { tokens?: number | null; contextWindow?: number } | null;
-      compact?: (customInstructions?: string) => Promise<unknown>;
-      isCompacting?: boolean;
-    };
-    if (typeof session.compact !== "function" || session.isCompacting) {
-      return;
-    }
-    const usage = session.getContextUsage?.();
-    const tokens = typeof usage?.tokens === "number" ? usage.tokens : null;
-    const contextWindow =
-      typeof usage?.contextWindow === "number" ? usage.contextWindow : 0;
-    if (tokens === null || contextWindow <= 0) {
-      return;
-    }
-    if (tokens <= contextWindow - piCompactionReserveTokens(contextWindow)) {
-      return;
-    }
-    try {
-      // Compaction sends the full history to be summarized, so an image-bloated
-      // transcript would 413 the compaction request just like the turn did. Prune
-      // oversized inline images first so the summary request stays sendable.
-      capSessionImageContext(session);
-      await session.compact();
-    } catch (error) {
+    const outcome = await compactSessionOverThreshold(handle.session);
+    if (outcome.status === "failed") {
       console.warn("pi end-of-turn compaction failed (non-fatal)", {
-        error: error instanceof Error ? error.message : String(error),
+        error: outcome.error,
       });
     }
   };


### PR DESCRIPTION
Replaces #524, which GitHub auto-closed when #523's branch was deleted on merge. Same commit, rebased onto `main`.

Answers "how can resume, deferral and compaction be tested by you instead of by me". All three were verifiable only by driving the desktop and watching for an **absence** — a session file that kept growing, a turn that didn't get cut off, a context that didn't overflow. None fail loudly, so "it looked fine" was the whole test.

## Resume — the seam, not the halves

Both halves were already covered: a terminal event persists `harness_session_id`, and bootstrap can load one. What was missing is that **they meet**. The write goes to `.holaboss/state/harness-session-state.json` (v2); the read also accepts a legacy v1 file at a different path. Two sides addressing the same fact through different paths and formats — each can stay green while the seam between them stops working.

When it breaks, nothing errors: every turn starts a fresh pi session and the agent quietly forgets the conversation. Now asserted across four consecutive turns, plus that a failed run clears the pointer.

## Deferral — real child, real signals

runner-worker SIGTERMs the runner on **every** terminal event, and with pi in-process that signal lands while compaction and dispose are still running. Signal disposition is process-global and can't be observed from inside the process that owns it, so each case stages a turn in a child and sends it a genuine signal.

Covers: SIGTERM and SIGINT deferral, the grace timer bounding a wedged turn, repeated signals not stacking timers, and that the deferral **releases** afterwards rather than leaving the runner killable only by SIGKILL.

Mutation-checked — with the guard removed, all four fail.

## Compaction — a decision that was invisible

The trigger lived in a closure over a live `AgentSession`, reachable only by a conversation long enough to cross half the context window. Its failure path wrote a `console.warn`, which in-process lands in ts-runner's **buffered stderr — surfaced only when a run FAILS**. Compaction failing doesn't fail the run, so the one signal that it broke went to a stream nobody reads.

Extracted as `compactSessionOverThreshold` returning an outcome, so both "did it run" and "did it work" are assertable values. Tests pin the boundary exactly (100,000 of a 200,000 window doesn't compact; one token over does), failure reporting, the re-entrancy guard, and unusable-usage skips.

## One thing deliberately not changed

`endInProcessTurn` looks like it should take the deferred signal once the turn settles. It must not: it runs in a `finally` inside the harness call, and the runner still has post-run persistence to do — exiting there would truncate exactly what resume depends on. Now documented in place. The process leaves by draining its loop; the grace timer is the backstop.

## Testing

api-server 1156 pass / 0 fail (+7), harness-host 303 pass / 0 fail (+5). Both typecheck clean. The deferral suite runs in ~2.6s despite spawning children. All checks were green on #524 before the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)