### PR TITLE
fix(runtime): let end-of-turn compaction finish — grace window (POSIX) and force-kill (Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,34 +159,38 @@ jobs:
       # pi already accepts Debian's `fdfind` as a system name for fd, so no
       # symlink is needed here.
       - name: Install search tools (rg, fd)
-        # Bounded and retried because this step is the one that hangs: apt has
-        # no timeout of its own, so a slow Ubuntu mirror stalls here
-        # indefinitely. Observed twice in a row at 12+ minutes on a step that
-        # normally takes seconds, never reaching the tests at all.
-        timeout-minutes: 4
+        # rg and fd are real test dependencies here: pi-search-tool.ts and
+        # pi-find-tool.ts shell out to them, and pi.test.ts covers both.
+        #
+        # This step is what hung the job — twice, at 12+ minutes, never reaching
+        # the tests. It produced NO output before timing out, which rules out a
+        # slow mirror: apt was blocked before it made any request, waiting on
+        # the dpkg/apt lock that unattended-upgrades holds early in a runner's
+        # life. Acquire timeouts do not apply to a lock wait, which is why the
+        # first attempt at bounding this did not help.
+        #
+        # DPkg::Lock::Timeout is the setting that does apply. -qq is gone
+        # deliberately: it suppressed the "waiting for lock" line that would
+        # have identified this immediately.
+        timeout-minutes: 8
         run: |
           set -u
           if command -v rg >/dev/null && (command -v fd >/dev/null || command -v fdfind >/dev/null); then
             rg --version | head -1
             exit 0
           fi
+          apt_opts="-o DPkg::Lock::Timeout=120 -o Acquire::Retries=2 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"
           for attempt in 1 2; do
-            # -o timeouts keep a wedged mirror from consuming the whole budget,
-            # leaving room for the second attempt to reach a different one.
-            if sudo apt-get -o Acquire::Retries=2 \
-                            -o Acquire::http::Timeout=20 \
-                            -o Acquire::https::Timeout=20 update -qq \
-               && sudo apt-get -o Acquire::Retries=2 \
-                               -o Acquire::http::Timeout=20 \
-                               -o Acquire::https::Timeout=20 install -y -qq ripgrep fd-find; then
+            echo "apt attempt ${attempt}"
+            if sudo apt-get ${apt_opts} update \
+               && sudo apt-get ${apt_opts} install -y ripgrep fd-find; then
               break
             fi
-            echo "apt attempt ${attempt} failed"
             if [ "${attempt}" = "2" ]; then
               echo "could not install search tools after 2 attempts" >&2
               exit 1
             fi
-            sleep 5
+            sleep 10
           done
           rg --version | head -1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ env:
 jobs:
   desktop-typecheck:
     if: ${{ github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
@@ -118,6 +119,7 @@ jobs:
 
   runtime-tests:
     if: ${{ github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -157,11 +159,35 @@ jobs:
       # pi already accepts Debian's `fdfind` as a system name for fd, so no
       # symlink is needed here.
       - name: Install search tools (rg, fd)
+        # Bounded and retried because this step is the one that hangs: apt has
+        # no timeout of its own, so a slow Ubuntu mirror stalls here
+        # indefinitely. Observed twice in a row at 12+ minutes on a step that
+        # normally takes seconds, never reaching the tests at all.
+        timeout-minutes: 4
         run: |
-          if ! command -v rg >/dev/null || ! (command -v fd >/dev/null || command -v fdfind >/dev/null); then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq ripgrep fd-find
+          set -u
+          if command -v rg >/dev/null && (command -v fd >/dev/null || command -v fdfind >/dev/null); then
+            rg --version | head -1
+            exit 0
           fi
+          for attempt in 1 2; do
+            # -o timeouts keep a wedged mirror from consuming the whole budget,
+            # leaving room for the second attempt to reach a different one.
+            if sudo apt-get -o Acquire::Retries=2 \
+                            -o Acquire::http::Timeout=20 \
+                            -o Acquire::https::Timeout=20 update -qq \
+               && sudo apt-get -o Acquire::Retries=2 \
+                               -o Acquire::http::Timeout=20 \
+                               -o Acquire::https::Timeout=20 install -y -qq ripgrep fd-find; then
+              break
+            fi
+            echo "apt attempt ${attempt} failed"
+            if [ "${attempt}" = "2" ]; then
+              echo "could not install search tools after 2 attempts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
           rg --version | head -1
 
       # Covers every runtime package that isn't the api-server (which has its
@@ -188,6 +214,7 @@ jobs:
 
   sdk-app-sdk:
     if: ${{ github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -218,6 +245,7 @@ jobs:
 
   runtime-api-server:
     if: ${{ github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -250,6 +278,7 @@ jobs:
 
   packages:
     if: ${{ github.event_name != 'workflow_dispatch' }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/runtime/api-server/src/in-process-termination.test.ts
+++ b/runtime/api-server/src/in-process-termination.test.ts
@@ -202,3 +202,26 @@ test("repeated signals during one turn do not stack grace timers", async () => {
     child.process.kill("SIGKILL");
   }
 });
+
+test("the deferral grace leaves real room for end-of-turn compaction", async () => {
+  // The grace timer's whole job is to outlast the slowest post-terminal work,
+  // and that is compaction. Because runner-worker signals ON the terminal
+  // event, compaction and this timer start together — the grace is the entire
+  // budget compaction gets.
+  //
+  // Measured on a real session (claude-sonnet-5, 1M context => 500k threshold):
+  // 13.2s to compact an 84k-token session, 26.1s for a 621k one. The old 30s
+  // default left under 4s of headroom on a session that had only just become
+  // eligible — and eligible sessions are the only ones that compact, so that
+  // margin applied to every real compaction there is.
+  //
+  // Pinned as a ratio rather than a literal so tightening the grace fails here
+  // instead of silently reintroducing the race.
+  const { IN_PROCESS_TERMINATION_GRACE_MS, MEASURED_MAX_COMPACTION_MS } =
+    await import("./ts-runner.js");
+
+  assert.ok(
+    IN_PROCESS_TERMINATION_GRACE_MS >= MEASURED_MAX_COMPACTION_MS * 3,
+    `grace ${IN_PROCESS_TERMINATION_GRACE_MS}ms leaves too little room for a ${MEASURED_MAX_COMPACTION_MS}ms compaction — a killed compaction leaves the session uncompacted, so the next turn is bigger and even likelier to be killed`,
+  );
+});

--- a/runtime/api-server/src/runner-terminal-shutdown.test.ts
+++ b/runtime/api-server/src/runner-terminal-shutdown.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { terminateRunnerAfterTerminalEvent } from "./runtime-shell.js";
+
+/**
+ * How the runner is terminated after its terminal event.
+ *
+ * End-of-turn compaction runs AFTER that event, and the event is what prompts
+ * the termination — so whatever happens here is compaction's entire budget. A
+ * 621k-token compaction was measured at 26.1s.
+ *
+ * The platform is injected because the bug being fixed is Windows-only and
+ * cannot be reproduced on this machine: `killChildProcess` ignores the
+ * requested signal on win32 and runs `taskkill /t /f`, a hard kill no handler
+ * can defer, so signalling there killed compaction outright on every turn.
+ */
+
+function fakeChild(): { killed: boolean; pid: number } {
+  return { killed: false, pid: 1234 };
+}
+
+function recordingKill() {
+  const calls: string[] = [];
+  return {
+    calls,
+    kill: (_child: unknown, signal: NodeJS.Signals) => {
+      calls.push(signal);
+    },
+  };
+}
+
+test("POSIX signals the runner so it can defer until the turn settles", () => {
+  const { calls, kill } = recordingKill();
+  const timer = terminateRunnerAfterTerminalEvent(fakeChild() as never, {
+    platform: "darwin",
+    kill: kill as never,
+  });
+
+  assert.deepEqual(calls, ["SIGTERM"], "SIGTERM is catchable on POSIX");
+  assert.equal(
+    timer,
+    null,
+    "no escalation timer: the runner's own grace is the bound, and a second one would cut compaction off at whichever fired first",
+  );
+});
+
+test("Windows does NOT signal, because any signal there is a hard kill", () => {
+  // The whole bug. `killChildProcess(child, "SIGTERM")` on win32 runs
+  // `taskkill /pid <pid> /t /f`. There is no catchable termination signal for a
+  // Node child on Windows, so sending one guarantees compaction is truncated.
+  const { calls, kill } = recordingKill();
+  const timer = terminateRunnerAfterTerminalEvent(fakeChild() as never, {
+    platform: "win32",
+    kill: kill as never,
+    forceAfterMs: 50,
+  });
+
+  assert.deepEqual(
+    calls,
+    [],
+    "signalling on Windows force-kills the process tree and truncates compaction",
+  );
+  assert.notEqual(timer, null, "but the wait must still be bounded");
+  if (timer) {
+    clearTimeout(timer);
+  }
+});
+
+test("Windows force-kills once the grace elapses", async () => {
+  // The runner normally exits on its own when the turn settles. This is the
+  // backstop for one that does not — the bound POSIX gets from the runner's own
+  // grace timer.
+  const { calls, kill } = recordingKill();
+  terminateRunnerAfterTerminalEvent(fakeChild() as never, {
+    platform: "win32",
+    kill: kill as never,
+    forceAfterMs: 20,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.deepEqual(calls, ["SIGKILL"], "a wedged runner must still be reclaimed");
+});
+
+test("a runner that already exited is not killed again", async () => {
+  const { calls, kill } = recordingKill();
+  const child = fakeChild();
+  terminateRunnerAfterTerminalEvent(child as never, {
+    platform: "win32",
+    kill: kill as never,
+    forceAfterMs: 20,
+  });
+  // The normal case: the runner finishes compaction and exits by itself.
+  child.killed = true;
+
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.deepEqual(calls, [], "no gratuitous kill after a clean exit");
+});
+
+test("the Windows grace leaves room for a real compaction", () => {
+  // 26.1s measured for a 621k-token compaction. The default must clear it by a
+  // wide margin, since a truncated compaction leaves the session uncompacted
+  // and makes the next turn larger still.
+  const { calls, kill } = recordingKill();
+  const timer = terminateRunnerAfterTerminalEvent(fakeChild() as never, {
+    platform: "win32",
+    kill: kill as never,
+  });
+  assert.notEqual(timer, null);
+  assert.deepEqual(calls, [], "must not kill synchronously");
+  if (timer) {
+    // Node exposes the scheduled delay on the handle; assert the default is
+    // generous rather than trusting the constant by eye.
+    const delay = (timer as unknown as { _idleTimeout: number })._idleTimeout;
+    assert.ok(
+      delay >= 26_100 * 3,
+      `default grace ${delay}ms leaves too little room for a 26.1s compaction`,
+    );
+  }
+});

--- a/runtime/api-server/src/runner-worker.ts
+++ b/runtime/api-server/src/runner-worker.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   killChildProcess,
+  terminateRunnerAfterTerminalEvent,
   quoteShellValue,
   runtimeShellKind,
   shellPathDelimiter,
@@ -839,7 +840,7 @@ export async function executeRunnerRequest(
         }
         if (TERMINAL_EVENT_TYPES.has(parsed.event_type as string)) {
           sawTerminal = true;
-          killChildProcess(child, "SIGTERM");
+          terminateRunnerAfterTerminalEvent(child);
         }
       }
     }
@@ -869,7 +870,7 @@ export async function executeRunnerRequest(
         }
         if (TERMINAL_EVENT_TYPES.has(parsed.event_type as string)) {
           sawTerminal = true;
-          killChildProcess(child, "SIGTERM");
+          terminateRunnerAfterTerminalEvent(child);
         }
       } else {
         appendSkippedLine(skippedLines, trailingLine);
@@ -1112,7 +1113,7 @@ export class NativeRunnerExecutor implements RunnerExecutorLike {
             clearTimeout(heartbeat);
           }
           clearWatchdogs();
-          killChildProcess(child, "SIGTERM");
+          terminateRunnerAfterTerminalEvent(child);
         }
       }
     });

--- a/runtime/api-server/src/runtime-shell.ts
+++ b/runtime/api-server/src/runtime-shell.ts
@@ -111,6 +111,69 @@ export function killChildProcess(
   }
 }
 
+/**
+ * Bound on how long the runner may keep working after its terminal event
+ * before it is force-killed. Mirrors IN_PROCESS_TERMINATION_GRACE_MS in
+ * ts-runner (duplicated rather than imported — the dependency would be a cycle,
+ * and this file must stay free of runner internals).
+ */
+const RUNNER_POST_TERMINAL_GRACE_MS = 120_000;
+
+/**
+ * Terminate the runner after its terminal event — without cutting off the work
+ * that runs *after* that event.
+ *
+ * End-of-turn compaction runs after the terminal event, and the terminal event
+ * is exactly what prompts this call. A 621k-token compaction was measured at
+ * 26.1s, so anything that kills the runner promptly here truncates it, leaving
+ * the session uncompacted; the next turn is then larger and likelier to be
+ * truncated again.
+ *
+ * The two platforms need opposite treatment, which is the bug this fixes:
+ *
+ *  - POSIX: SIGTERM is catchable, so the runner defers it until the turn
+ *    settles and then leaves by draining its event loop. Unchanged.
+ *
+ *  - Windows: there is NO catchable termination signal for a Node child.
+ *    `child.kill("SIGTERM")` is an abrupt TerminateProcess, which is why
+ *    killChildProcess falls back to `taskkill /t /f` — a hard kill no handler
+ *    can defer. Signalling at all on Windows therefore guarantees compaction is
+ *    killed, every turn. So we send nothing and let the runner exit on its own,
+ *    with a force-kill as the backstop the POSIX side gets from the runner's
+ *    own grace timer.
+ *
+ * The Windows path predates the in-process harness: the spawned harness-host
+ * sat inside the same `/t` process tree, so it was killed just the same.
+ */
+export function terminateRunnerAfterTerminalEvent(
+  child: ChildLike,
+  options: {
+    platform?: NodeJS.Platform;
+    forceAfterMs?: number;
+    kill?: (child: ChildLike, signal: NodeJS.Signals) => void;
+  } = {},
+): NodeJS.Timeout | null {
+  const platform = options.platform ?? process.platform;
+  const kill = options.kill ?? killChildProcess;
+
+  if (platform !== "win32") {
+    kill(child, "SIGTERM");
+    // No escalation: the runner's own grace timer is the bound on POSIX, and
+    // adding a second one here would cut compaction off at whichever fires
+    // first — reintroducing the race from the other side.
+    return null;
+  }
+
+  const forceAfterMs = options.forceAfterMs ?? RUNNER_POST_TERMINAL_GRACE_MS;
+  const timer = setTimeout(() => {
+    if (!child.killed) {
+      kill(child, "SIGKILL");
+    }
+  }, forceAfterMs);
+  timer.unref?.();
+  return timer;
+}
+
 export function buildPortListenerKillCommand(
   ports: number[],
   platform: NodeJS.Platform = process.platform,

--- a/runtime/api-server/src/ts-runner.ts
+++ b/runtime/api-server/src/ts-runner.ts
@@ -1819,9 +1819,43 @@ function parseHarnessHostRunnerEvent(
  * signal indefinitely. With no turn in flight the signal behaves exactly as it
  * does today.
  */
-const IN_PROCESS_TERMINATION_GRACE_MS = Number(
+/**
+ * How long a deferred SIGTERM waits for the in-flight turn to settle.
+ *
+ * This has to cover END-OF-TURN COMPACTION, which is the slowest thing that
+ * runs after the terminal event — and the terminal event is exactly what makes
+ * runner-worker send the signal, so compaction and this timer start together.
+ *
+ * Measured against a real session (claude-sonnet-5, 1M context window, so the
+ * compaction threshold is 500k tokens):
+ *
+ *   84k-token session    13.2s
+ *   621k-token session   26.1s   <- a session that just crossed the threshold
+ *
+ * The previous 30s left under 4 seconds of margin on a compaction that had
+ * only just become eligible. Sessions above the threshold are the ONLY ones
+ * that compact, so that margin applied to every real compaction there is; a
+ * slightly larger session, or any upstream slowness, and the timer would kill
+ * the summarization mid-flight.
+ *
+ * The failure is self-reinforcing, which is what makes a tight bound expensive:
+ * a killed compaction leaves the session uncompacted, so the next turn is
+ * larger, takes longer to summarize, and is more likely to be killed again.
+ *
+ * Raising it costs little. The parent does not escalate to SIGKILL after the
+ * terminal event (runner-worker clears its watchdogs first), so this timer is
+ * the only bound — but it is a backstop, not the normal exit: the runner
+ * normally leaves by draining its event loop as soon as the turn settles. A
+ * longer grace delays nothing the user waits on, since the turn has already
+ * produced its result by the time the signal arrives.
+ */
+export const IN_PROCESS_TERMINATION_GRACE_MS = Number(
   process.env.HB_HARNESS_IN_PROCESS_GRACE_MS ?? "",
-) || 30_000;
+) || 120_000;
+
+/** Longest end-of-turn compaction measured on a real session, in ms. The grace
+ *  above must stay comfortably clear of this — see the note there. */
+export const MEASURED_MAX_COMPACTION_MS = 26_100;
 let inProcessTurnsActive = 0;
 let inProcessTerminationDeferred = false;
 let inProcessSignalGuardInstalled = false;


### PR DESCRIPTION
Two bugs that both truncate end-of-turn compaction. Found by driving a real 621k-token compaction rather than reasoning about it.

Shared root: runner-worker terminates the runner **on the terminal event**, and compaction runs *after* that event — so whatever happens there is compaction's entire budget.

Measured (claude-sonnet-5, 1M context → 500k compaction threshold):

| session | compaction |
|---|---|
| 84k tokens | 13.2s |
| **621k tokens** | **26.1s** |

## 1. POSIX: the grace window was 30s

The runner defers the SIGTERM, but only for 30s — under **4 seconds** of headroom on a session that had only just become eligible. Sessions above the threshold are the only ones that compact, so that margin applied to every real compaction there is.

Raised to 120s, pinned by a test as a **ratio** against the measured duration so tightening it fails loudly.

Costs nothing the user waits on: the turn has already produced its result when the signal arrives, and the runner normally exits by draining its event loop — the timer is a backstop for a *wedged* turn. It stays the only bound, since runner-worker clears its watchdogs before signalling and never escalates.

## 2. Windows: compaction never completed at all

Not intermittently — never. There is no catchable termination signal for a Node child on Windows: `child.kill("SIGTERM")` is an abrupt `TerminateProcess`, which is why `killChildProcess` falls back to `taskkill /pid <pid> /t /f`. A hard kill of the whole tree, deferrable by nothing.

The fix isn't a different signal; there isn't one. Send **nothing** on Windows and let the runner exit on its own, with a force-kill backstop providing the bound POSIX gets from the runner's own grace timer.

Applied at the three terminal-event sites. Deliberately **not** applied to the stream-close path, where the consumer abandoned the turn and prompt termination is correct.

This predates the in-process harness (the spawned harness-host sat in the same `/t` tree). Not a regression from that work — it's what made it *visible*, because compaction failures stopped being silent.

## Why neither was caught

Both are structurally invisible to the debug CLI: `hola` has no runner-worker, so nothing ever signals. Only a real turn exercises them.

## Testing

Windows behaviour is tested with the **platform injected**, since this machine can't reproduce it: POSIX still signals and takes no escalation timer; Windows signals nothing; the backstop still reclaims a wedged runner; a cleanly-exited runner isn't killed again; the default grace clears 26.1s by a wide margin.

api-server 1162 pass / 0 fail, typecheck clean.

## Not verified

**Neither fix has been watched on a real Windows turn**, and the POSIX grace change hasn't been observed under a live SIGTERM either — `hola` can't send one. Both are pinned by tests and grounded in measurement, but the end-to-end behaviour is unconfirmed.

Also still unexplained: a separate `Summarization failed: Request timed out.` from the model **upstream**, seen once at ~570k with the runtime alive. That is a different failure from these two and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)