### PR TITLE
ci: install rg and fd from upstream releases instead of apt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,40 +159,63 @@ jobs:
       # pi already accepts Debian's `fdfind` as a system name for fd, so no
       # symlink is needed here.
       - name: Install search tools (rg, fd)
-        # rg and fd are real test dependencies here: pi-search-tool.ts and
-        # pi-find-tool.ts shell out to them, and pi.test.ts covers both.
+        # rg and fd are real test dependencies: pi-search-tool.ts and
+        # pi-find-tool.ts resolve them via ensureTool("rg") / ensureTool("fd"),
+        # and pi.test.ts covers both. Neither ships in the runner image.
         #
-        # This step is what hung the job — twice, at 12+ minutes, never reaching
-        # the tests. It produced NO output before timing out, which rules out a
-        # slow mirror: apt was blocked before it made any request, waiting on
-        # the dpkg/apt lock that unattended-upgrades holds early in a runner's
-        # life. Acquire timeouts do not apply to a lock wait, which is why the
-        # first attempt at bounding this did not help.
+        # Installed from upstream release tarballs rather than apt, because apt
+        # is what kept breaking this job. Azure's Ubuntu mirror started
+        # returning Ign: for every index, and the fallback to archive.ubuntu.com
+        # stalled — twice as a silent 12-minute hang, then again as an 8-minute
+        # timeout on main. Acquire::*::Timeout did not bound it: apt kept the
+        # connection and simply made no progress.
         #
-        # DPkg::Lock::Timeout is the setting that does apply. -qq is gone
-        # deliberately: it suppressed the "waiting for lock" line that would
-        # have identified this immediately.
-        timeout-minutes: 8
+        # These are single static musl binaries from the same GitHub CDN the
+        # workflow already depends on for checkout, so this removes a
+        # third-party outage from the critical path rather than tolerating it.
+        # apt stays as a fallback, still bounded.
+        timeout-minutes: 6
+        env:
+          RG_VERSION: "14.1.1"
+          FD_VERSION: "10.2.0"
         run: |
-          set -u
-          if command -v rg >/dev/null && (command -v fd >/dev/null || command -v fdfind >/dev/null); then
+          set -euo pipefail
+          if command -v rg >/dev/null && command -v fd >/dev/null; then
             rg --version | head -1
+            fd --version
             exit 0
           fi
-          apt_opts="-o DPkg::Lock::Timeout=120 -o Acquire::Retries=2 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20"
-          for attempt in 1 2; do
-            echo "apt attempt ${attempt}"
-            if sudo apt-get ${apt_opts} update \
-               && sudo apt-get ${apt_opts} install -y ripgrep fd-find; then
-              break
+
+          tmp="$(mktemp -d)"
+          fetch() {
+            curl --fail --location --silent --show-error \
+                 --retry 3 --retry-delay 2 --retry-connrefused \
+                 --connect-timeout 15 --max-time 120 \
+                 --output "$2" "$1"
+          }
+
+          if fetch "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz" "$tmp/rg.tar.gz" \
+             && fetch "https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/fd-v${FD_VERSION}-x86_64-unknown-linux-musl.tar.gz" "$tmp/fd.tar.gz"; then
+            tar -xzf "$tmp/rg.tar.gz" -C "$tmp"
+            tar -xzf "$tmp/fd.tar.gz" -C "$tmp"
+            # --strip-components is avoided: the two archives nest differently,
+            # so the binaries are located rather than assumed.
+            sudo install -m 0755 "$(find "$tmp" -type f -name rg -perm -u+x | head -1)" /usr/local/bin/rg
+            sudo install -m 0755 "$(find "$tmp" -type f -name fd -perm -u+x | head -1)" /usr/local/bin/fd
+          else
+            echo "release download failed; falling back to apt" >&2
+            apt_opts="-o DPkg::Lock::Timeout=60 -o Acquire::Retries=2 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15"
+            sudo apt-get ${apt_opts} update
+            sudo apt-get ${apt_opts} install -y ripgrep fd-find
+            # Debian names the binary fdfind; the tools look for fd.
+            if ! command -v fd >/dev/null && command -v fdfind >/dev/null; then
+              sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
             fi
-            if [ "${attempt}" = "2" ]; then
-              echo "could not install search tools after 2 attempts" >&2
-              exit 1
-            fi
-            sleep 10
-          done
+          fi
+
+          rm -rf "$tmp"
           rg --version | head -1
+          fd --version
 
       # Covers every runtime package that isn't the api-server (which has its
       # own job). runtime-harnesses and runtime-channel-gateway both have test


### PR DESCRIPTION
**`main` is currently red.** It has been failing all morning in the same place: "Install search tools (rg, fd)", which never reaches the tests.

## The actual cause

Removing `-qq` finally showed it — and it is **not** the dpkg lock I guessed at last round:

```
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease          ← fallback
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease
   ...nothing for 7m48s, then timeout
```

Azure's Ubuntu mirror is returning `Ign:` for every index. apt falls back to `archive.ubuntu.com` and stalls there. `Acquire::*::Timeout` doesn't bound this — the connection stays up and simply makes no progress, which those options don't cover.

That's also why the first two occurrences looked like a *hang* rather than a failure: `-qq` was suppressing exactly these lines.

## The fix

`rg` and `fd` are genuine test dependencies — `pi-search-tool.ts` and `pi-find-tool.ts` resolve them via `ensureTool`, `pi.test.ts` covers both — and neither ships in the runner image, so the install can't be skipped.

They're now fetched as **pinned static musl binaries from the same GitHub CDN the workflow already trusts for checkout**, taking a third-party mirror off the critical path instead of tolerating its outages. apt stays as a bounded fallback, and symlinks Debian's `fdfind` → `fd`.

## Verified locally

- Both tarballs download (HTTP 200, with retries/timeouts)
- The two archives **nest differently** (`ripgrep-14.1.1-…` vs `fd-v10.2.0-…`) — which is why binaries are located with `find` rather than assumed at a fixed `--strip-components` depth
- Extracted `rg` is a static-pie x86-64 ELF, matching the runner
- Shell parses (`bash -n`)

## Note on my previous round

The `DPkg::Lock::Timeout` change I made earlier was aimed at the wrong thing. It's harmless and stays in the fallback path, but the silence I read as "blocked before any request" was just `-qq`. Worth stating plainly: I fixed before diagnosing, and it cost a round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)