### PR TITLE
fix(desktop): stop the end-of-turn flash, and show a new session in the sidebar immediately

### DIFF
--- a/apps/desktop/src/components/layout/shell/mainSessionsRefresh.test.ts
+++ b/apps/desktop/src/components/layout/shell/mainSessionsRefresh.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * A session created from the composer must appear in the sidebar immediately.
+ *
+ * The main-session lists are poll-driven at 5s. That is fine for change caused
+ * elsewhere, but wrong for change this client just made: after sending the
+ * first message of a new session, the session existed server-side and was
+ * selected in the pane, while the sidebar had no row for it for up to a full
+ * poll interval — the session the user had just started was on screen nowhere.
+ *
+ * Structural, in a `.test.ts` deliberately: `test:unit` globs `.test.ts` /
+ * `.test.tsx`, so a guard written as `.mjs` under src/ would never run.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const listsSource = readFileSync(
+  path.join(here, "useWorkspaceLists.ts"),
+  "utf-8",
+);
+const chatPaneSource = readFileSync(
+  path.join(here, "..", "..", "panes", "ChatPane", "index.tsx"),
+  "utf-8",
+);
+
+test("the main-sessions hook refreshes on a broadcast, not only on its poll", () => {
+  assert.match(
+    listsSource,
+    /export function notifyMainSessionsChanged\(\): void/,
+    "the broadcast helper must exist and take no payload",
+  );
+  assert.match(
+    listsSource,
+    /addEventListener\(MAIN_SESSIONS_CHANGED/,
+    "useWorkspaceMainSessions must subscribe to it",
+  );
+  assert.match(
+    listsSource,
+    /removeEventListener\(MAIN_SESSIONS_CHANGED/,
+    "and unsubscribe on cleanup, or every remount leaks a listener that reloads forever",
+  );
+});
+
+test("the broadcast carries no fabricated session row", () => {
+  // createAgentSession returns an AgentSessionRecordPayload, which has no
+  // is_active and so is not a MainSessionRecordPayload. Inserting it
+  // optimistically would mean inventing that field — a row on screen whose
+  // state was guessed. A reload is one local IPC, so the row still appears
+  // immediately; it is just the server's row instead of ours.
+  const helper =
+    /export function notifyMainSessionsChanged\(\)[\s\S]*?\n}/.exec(listsSource)?.[0] ??
+    "";
+  assert.ok(helper.length > 0, "helper not found");
+  assert.doesNotMatch(
+    helper,
+    /is_active/,
+    "the signal must not carry a synthesized session record",
+  );
+});
+
+test("both session-creation paths in ChatPane broadcast", () => {
+  // Two places create a session: createWorkspaceSession (the composer's first
+  // send) and the app/main-session path. Missing either leaves the original
+  // 5s gap on that route.
+  const calls = chatPaneSource.match(/notifyMainSessionsChanged\(\)/g) ?? [];
+  assert.equal(
+    calls.length,
+    2,
+    `expected both creation paths to broadcast, found ${calls.length}`,
+  );
+});

--- a/apps/desktop/src/components/layout/shell/mainSessionsRefresh.test.ts
+++ b/apps/desktop/src/components/layout/shell/mainSessionsRefresh.test.ts
@@ -62,14 +62,29 @@ test("the broadcast carries no fabricated session row", () => {
   );
 });
 
-test("both session-creation paths in ChatPane broadcast", () => {
-  // Two places create a session: createWorkspaceSession (the composer's first
-  // send) and the app/main-session path. Missing either leaves the original
-  // 5s gap on that route.
+test("ChatPane broadcasts from every path that can make a session listable", () => {
+  // Three: the two creation paths, plus — critically — the point where the
+  // input is queued.
   const calls = chatPaneSource.match(/notifyMainSessionsChanged\(\)/g) ?? [];
   assert.equal(
     calls.length,
-    2,
-    `expected both creation paths to broadcast, found ${calls.length}`,
+    3,
+    `expected creation paths plus the queue-accepted path, found ${calls.length}`,
+  );
+});
+
+test("the queue-accepted broadcast is the one that makes the row appear", () => {
+  // The sidebar hides titleless sessions (they are empty placeholders there),
+  // and the title is derived server-side from the first user message by the
+  // queue-input route. Broadcasting only at creation reloads a list in which
+  // the session is still untitled and therefore still filtered out — the row
+  // waits for the next 5s poll regardless. The broadcast has to happen after
+  // the queue call returns.
+  const afterAccept = /queueAccepted = true;[\s\S]{0,1200}?notifyMainSessionsChanged\(\)/.test(
+    chatPaneSource,
+  );
+  assert.ok(
+    afterAccept,
+    "expected a broadcast shortly after queueAccepted = true",
   );
 });

--- a/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
+++ b/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
@@ -281,6 +281,33 @@ function reconcileMainSessions(
 // `appId` scopes the list to one HolaApp's own sessions (the app session
 // dropdown). Omitted, the hook returns the workspace sidebar list, which the
 // runtime already strips of app-owned sessions.
+/**
+ * Immediate refresh signal for the main-session lists.
+ *
+ * The lists are poll-driven at POLL_INTERVAL_MS, which is fine for change that
+ * happens elsewhere but wrong for change this client just caused: creating a
+ * session from the composer left the sidebar without a row for it for up to a
+ * full poll interval, so the session the user had just started did not exist
+ * anywhere on screen.
+ *
+ * Four components call useWorkspaceMainSessions and each keeps its own state,
+ * so this is a broadcast rather than a shared cache: every subscriber reloads
+ * at once.
+ *
+ * It deliberately carries no payload. The creation call returns an
+ * AgentSessionRecordPayload, which is not a MainSessionRecordPayload — it has
+ * no is_active — and inventing that field to enable an optimistic insert would
+ * put a row on screen whose state was guessed rather than observed. A reload is
+ * one local IPC, so the row still appears immediately; it is simply the
+ * server's row rather than one we made up.
+ */
+const mainSessionsChanged = new EventTarget();
+const MAIN_SESSIONS_CHANGED = "main-sessions-changed";
+
+export function notifyMainSessionsChanged(): void {
+  mainSessionsChanged.dispatchEvent(new Event(MAIN_SESSIONS_CHANGED));
+}
+
 export function useWorkspaceMainSessions(
   workspaceId: string | null,
   appId?: string | null,
@@ -321,9 +348,16 @@ export function useWorkspaceMainSessions(
     };
     void load();
     const timer = window.setInterval(load, POLL_INTERVAL_MS);
+
+    const onChanged = () => {
+      void load();
+    };
+    mainSessionsChanged.addEventListener(MAIN_SESSIONS_CHANGED, onChanged);
+
     return () => {
       cancelled = true;
       window.clearInterval(timer);
+      mainSessionsChanged.removeEventListener(MAIN_SESSIONS_CHANGED, onChanged);
     };
   }, [workspaceId, appId, activeOrgId]);
 

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.test.ts
@@ -60,9 +60,46 @@ test("live turn shows the active step, spinning, once", () => {
   });
 });
 
-test("live streaming of the final answer hides the top anchor", () => {
+test("live streaming of the final answer keeps the anchor but stops it spinning", () => {
+  // It used to return null here. That removed the row while the answer streamed
+  // and restored it as "Worked for Ns" on completion — inserting a line into a
+  // settled turn and shoving everything below it down the instant the agent
+  // stopped typing.
   const segments = [exec([step({ id: "a" })]), out("后台已开始拉")];
-  assert.equal(resolveTurnStatus(segments, { live: true }), null);
+  assert.deepEqual(resolveTurnStatus(segments, { live: true }), {
+    label: "Working",
+    spinning: false,
+    tone: "default",
+  });
+});
+
+test("the anchor does not appear or vanish between streaming and settled", () => {
+  // The actual regression guard: whether a turn shows an anchor must not change
+  // when `live` flips, or the layout shifts by one row at that exact moment.
+  const withTools = [exec([step({ id: "a" })]), out("done")];
+  const plainReply = [out("hi there")];
+
+  for (const [name, segments] of [
+    ["a turn that ran tools", withTools],
+    ["a plain text reply", plainReply],
+  ] as const) {
+    const streaming = resolveTurnStatus(segments, { live: true });
+    const settled = resolveTurnStatus(segments, { live: false, workedMs: 9000 });
+    assert.equal(
+      streaming === null,
+      settled === null,
+      `${name}: anchor presence changed when the turn settled`,
+    );
+  }
+});
+
+test("the settled anchor is the one the streaming anchor becomes", () => {
+  const segments = [exec([step({ id: "a" })]), out("done")];
+  assert.equal(resolveTurnStatus(segments, { live: true })?.label, "Working");
+  assert.equal(
+    resolveTurnStatus(segments, { live: false, workedMs: 9000 })?.label,
+    "Worked for 9s",
+  );
 });
 
 test("terminal error wins over duration", () => {

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.test.ts
@@ -23,15 +23,30 @@ const exec = (steps: ChatTraceStep[]): ChatAssistantSegment => ({
   })),
 });
 
-test("interleaved completed turn yields one Worked-for anchor", () => {
+test("an interleaved turn that ends with its answer yields no anchor", () => {
+  // Was "yields one Worked-for anchor". The collapse-to-one-anchor intent is
+  // unchanged — it is pinned by the next test — but a turn that ends with its
+  // streamed answer now shows no anchor in EITHER state, so nothing appears
+  // when it settles and the layout stays put.
   const segments = [
     exec([step({ id: "a" })]),
     out("没找到你的 GitHub 用户名。"),
     exec([step({ id: "b" }), step({ id: "c" })]),
     out("GitHub 已连接。"),
   ];
-  const status = resolveTurnStatus(segments, { live: false, workedMs: 40_000 });
-  assert.deepEqual(status, {
+  assert.equal(resolveTurnStatus(segments, { live: false, workedMs: 40_000 }), null);
+});
+
+test("a turn that ends on an execution segment still gets exactly one anchor", () => {
+  // The original point of the test above: a turn interleaves tool phases with
+  // narration, and the anchor collapses that to one turn-wide fact rather than
+  // repeating per phase.
+  const segments = [
+    exec([step({ id: "a" })]),
+    out("没找到你的 GitHub 用户名。"),
+    exec([step({ id: "b" }), step({ id: "c" })]),
+  ];
+  assert.deepEqual(resolveTurnStatus(segments, { live: false, workedMs: 40_000 }), {
     label: "Worked for 40s",
     spinning: false,
     tone: "default",
@@ -60,46 +75,42 @@ test("live turn shows the active step, spinning, once", () => {
   });
 });
 
-test("live streaming of the final answer keeps the anchor but stops it spinning", () => {
-  // It used to return null here. That removed the row while the answer streamed
-  // and restored it as "Worked for Ns" on completion — inserting a line into a
-  // settled turn and shoving everything below it down the instant the agent
-  // stopped typing.
+test("a turn that ends with its answer shows no anchor, streaming or settled", () => {
+  // The end-of-turn drift. The anchor used to be absent while the answer
+  // streamed and present once the turn settled ("Worked for Ns"), so a row
+  // appeared the instant the agent stopped typing and pushed the answer, its
+  // timestamp and everything below it down.
   const segments = [exec([step({ id: "a" })]), out("后台已开始拉")];
-  assert.deepEqual(resolveTurnStatus(segments, { live: true }), {
-    label: "Working",
-    spinning: false,
-    tone: "default",
-  });
+  assert.equal(resolveTurnStatus(segments, { live: true }), null);
+  assert.equal(
+    resolveTurnStatus(segments, { live: false, workedMs: 9000 }),
+    null,
+    "the duration is not worth moving the layout for; the trace is still under Details",
+  );
 });
 
-test("the anchor does not appear or vanish between streaming and settled", () => {
-  // The actual regression guard: whether a turn shows an anchor must not change
-  // when `live` flips, or the layout shifts by one row at that exact moment.
-  const withTools = [exec([step({ id: "a" })]), out("done")];
-  const plainReply = [out("hi there")];
+test("anchor presence never changes when a turn settles", () => {
+  // The property that actually matters: whatever the anchor does, it must do
+  // the same thing on both sides of the live -> settled flip, or the layout
+  // shifts by a row at that exact moment.
+  const cases = [
+    ["ends with its answer", [exec([step({ id: "a" })]), out("done")]],
+    ["plain text reply", [out("hi there")]],
+    ["ends on an execution segment", [out("working"), exec([step({ id: "b" })])]],
+  ] as const;
 
-  for (const [name, segments] of [
-    ["a turn that ran tools", withTools],
-    ["a plain text reply", plainReply],
-  ] as const) {
-    const streaming = resolveTurnStatus(segments, { live: true });
-    const settled = resolveTurnStatus(segments, { live: false, workedMs: 9000 });
+  for (const [name, segments] of cases) {
+    const streaming = resolveTurnStatus([...segments], { live: true });
+    const settled = resolveTurnStatus([...segments], {
+      live: false,
+      workedMs: 9000,
+    });
     assert.equal(
       streaming === null,
       settled === null,
       `${name}: anchor presence changed when the turn settled`,
     );
   }
-});
-
-test("the settled anchor is the one the streaming anchor becomes", () => {
-  const segments = [exec([step({ id: "a" })]), out("done")];
-  assert.equal(resolveTurnStatus(segments, { live: true })?.label, "Working");
-  assert.equal(
-    resolveTurnStatus(segments, { live: false, workedMs: 9000 })?.label,
-    "Worked for 9s",
-  );
 });
 
 test("terminal error wins over duration", () => {

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.ts
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.ts
@@ -96,10 +96,23 @@ export function resolveTurnStatus(
     segments.length > 0 ? segments[segments.length - 1] : null;
 
   if (live) {
-    // While the final answer streams, its text (with the live cursor) carries
-    // the signal — a top spinner on top of it just double-states "still going".
+    // While the final answer streams, its text (with the live cursor) already
+    // carries the "still going" signal, so this anchor drops its spinner —
+    // a second one on top of the cursor just double-states it.
+    //
+    // It must not drop the LINE, though. Returning null here and then falling
+    // through to "Worked for Ns" once the turn settles inserts a row into an
+    // already-laid-out turn, pushing the answer, its timestamp and everything
+    // below it down the moment the agent stops typing — the drift at the end
+    // of every turn that ran tools.
+    //
+    // "Working" -> "Worked for Ns" swaps the text of one line instead. The
+    // `items.length` rule mirrors the settled path below, so a plain text reply
+    // still gets no anchor in either state and still has nothing to insert.
     if (lastSegment?.kind === "output") {
-      return null;
+      return items.length > 0
+        ? { label: "Working", spinning: false, tone: "default" }
+        : null;
     }
     const activeStep = [...steps]
       .reverse()

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.ts
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnStatus.ts
@@ -96,23 +96,10 @@ export function resolveTurnStatus(
     segments.length > 0 ? segments[segments.length - 1] : null;
 
   if (live) {
-    // While the final answer streams, its text (with the live cursor) already
-    // carries the "still going" signal, so this anchor drops its spinner —
-    // a second one on top of the cursor just double-states it.
-    //
-    // It must not drop the LINE, though. Returning null here and then falling
-    // through to "Worked for Ns" once the turn settles inserts a row into an
-    // already-laid-out turn, pushing the answer, its timestamp and everything
-    // below it down the moment the agent stops typing — the drift at the end
-    // of every turn that ran tools.
-    //
-    // "Working" -> "Worked for Ns" swaps the text of one line instead. The
-    // `items.length` rule mirrors the settled path below, so a plain text reply
-    // still gets no anchor in either state and still has nothing to insert.
+    // While the final answer streams, its text (with the live cursor) carries
+    // the signal — a top spinner on top of it just double-states "still going".
     if (lastSegment?.kind === "output") {
-      return items.length > 0
-        ? { label: "Working", spinning: false, tone: "default" }
-        : null;
+      return null;
     }
     const activeStep = [...steps]
       .reverse()
@@ -155,6 +142,22 @@ export function resolveTurnStatus(
       spinning: false,
       tone: "default",
     };
+  }
+  // The same rule the live branch above uses: a turn that ends with its
+  // streamed answer gets no anchor.
+  //
+  // This is the fix for the end-of-turn drift, and it is a presence rule rather
+  // than a labelling one. The anchor was absent while the answer streamed and
+  // present once the turn settled, so a row appeared at the exact moment the
+  // agent stopped typing and pushed the answer, its timestamp and everything
+  // below it down. Anything that exists in only one of the two states moves the
+  // layout on the transition; the duration is not worth that, and the trace is
+  // still one click away under Details.
+  //
+  // A turn that ends on an execution segment keeps its anchor in BOTH states,
+  // so it does not move either.
+  if (lastSegment?.kind === "output") {
+    return null;
   }
   // Only turns that actually ran tools get a "Worked for" anchor; a plain text
   // reply shouldn't sprout a duration line it never had.

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -276,7 +276,10 @@ import {
   parseModelError,
   type ParsedModelError,
 } from "./ModelErrorRecovery";
-import { useWorkspaceProjects } from "@/components/layout/shell/useWorkspaceLists";
+import {
+  notifyMainSessionsChanged,
+  useWorkspaceProjects,
+} from "@/components/layout/shell/useWorkspaceLists";
 import { useHolaAppCatalog } from "@/components/layout/shell/useHolaAppCatalog";
 import { useOpenIssueDetailTab } from "@/components/layout/shell/useOpenIssueDetailTab";
 import { AppLandingSuggestions } from "./AppLandingSuggestions";
@@ -4931,6 +4934,11 @@ export function ChatPane({
       app_id: owningAppId ?? null,
     });
     const sessionId = created.session.session_id.trim();
+    if (sessionId) {
+      // The sidebar lists poll every 5s. Without this the session the user just
+      // started has no row anywhere on screen until the next tick.
+      notifyMainSessionsChanged();
+    }
     return sessionId || null;
   }
 
@@ -7319,6 +7327,7 @@ export function ChatPane({
           if (!owningAppId) {
             setDesktopMainSession(created.session);
           }
+          notifyMainSessionsChanged();
           setActiveSession(targetSessionId);
           setSidebarSelectedSessionId(targetSessionId);
           setSelectedSessionForWorkspace(

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -7685,6 +7685,14 @@ export function ChatPane({
       queueAccepted = true;
       rememberSubmittedComposerInput(text, selectedWorkspace.id);
       setActiveSession(queued.session_id);
+      // The sidebar hides sessions with no title — a titleless session is an
+      // empty placeholder there — and the title is derived server-side from
+      // this first user message, by the queue-input route we just called. So
+      // broadcasting at creation was a step too early: the reload came back
+      // with the session still untitled and the sidebar rightly filtered it
+      // out, leaving the row to wait for the next 5s poll anyway. This is the
+      // first moment the row can actually render.
+      notifyMainSessionsChanged();
       appendStreamTelemetry({
         streamId: "-",
         transportType: "client",

--- a/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.test.ts
@@ -100,3 +100,80 @@ test("several turns can be in flight at once", () => {
     "assistant-input-2",
   ]);
 });
+
+/**
+ * The turn came back present-but-bare.
+ *
+ * The history render rebuilds a turn's execution trace from its output events,
+ * and the conversation refresh does not wait for them. So the server's copy
+ * lands carrying the text but no trace, and the "Worked for Ns" anchor and
+ * Details disclosure blink out until a later rung fills them in — the flicker
+ * that survived preserving *absent* turns, because this turn was never absent.
+ */
+
+const withTrace = (id: string): ChatMessage => ({
+  id,
+  role: "assistant",
+  text: "Hey Jeff! What are we working on today?",
+  segments: [
+    { kind: "execution", items: [{ kind: "trace", id: "t1", label: "thinking" }] },
+    { kind: "output", text: "Hey Jeff! What are we working on today?" },
+  ] as ChatMessage["segments"],
+});
+
+const bare = (id: string): ChatMessage => ({
+  id,
+  role: "assistant",
+  text: "Hey Jeff! What are we working on today?",
+  segments: [{ kind: "output", text: "Hey Jeff! What are we working on today?" }],
+});
+
+test("a server copy without its trace does not replace the complete local one", () => {
+  const result = preserveCommittedAssistantTurns(
+    [{ id: "u1", role: "user", text: "hey" }, bare("a1")],
+    [withTrace("a1")],
+  );
+
+  assert.equal(result.length, 2, "must not duplicate the turn");
+  const assistant = result.find((message) => message.id === "a1");
+  assert.ok(
+    assistant?.segments?.some((segment) => segment.kind === "execution"),
+    "the execution trace must survive a refresh that arrived without it",
+  );
+});
+
+test("the server copy wins once it carries the trace", () => {
+  const server = withTrace("a1");
+  server.text = "server copy";
+  const result = preserveCommittedAssistantTurns([server], [withTrace("a1")]);
+  assert.equal(
+    result[0]?.text,
+    "server copy",
+    "the server's copy is authoritative once it is complete",
+  );
+});
+
+test("a turn that never had a trace is not held back", () => {
+  // A plain text reply runs no tools and gets no chrome; substituting for it
+  // would hold the local copy forever against a server copy that is correct.
+  const result = preserveCommittedAssistantTurns([bare("a1")], [bare("a1")]);
+  assert.equal(result.length, 1);
+  assert.equal(
+    settleCommittedAssistantTurns([bare("a1")], [bare("a1")]).length,
+    0,
+    "it must settle immediately",
+  );
+});
+
+test("settling waits for the trace, not just the id", () => {
+  assert.equal(
+    settleCommittedAssistantTurns([withTrace("a1")], [bare("a1")]).length,
+    1,
+    "present-but-bare is not caught up",
+  );
+  assert.equal(
+    settleCommittedAssistantTurns([withTrace("a1")], [withTrace("a1")]).length,
+    0,
+    "a complete server copy settles it",
+  );
+});

--- a/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.ts
+++ b/apps/desktop/src/components/panes/ChatPane/preserveCommittedAssistantTurns.ts
@@ -22,6 +22,25 @@ import type { ChatMessage } from "./types";
  * half of that symmetry: hold locally committed turns until the persisted turn
  * shows up, then let the server's copy win.
  */
+/**
+ * Does this turn carry the execution trace that renders its "Worked for Ns"
+ * anchor and Details disclosure?
+ *
+ * Mirrors the check the pane itself uses to decide a turn has execution
+ * content (index.tsx, hasExecutionOnlyContent). The trace lives in either
+ * shape: still-streaming turns accumulate `executionItems`, and a settled turn
+ * has them folded into an `execution` segment.
+ */
+function hasExecutionTrace(message: ChatMessage): boolean {
+  return (
+    (message.executionItems?.length ?? 0) > 0 ||
+    (message.segments?.some(
+      (segment) => segment.kind === "execution" && segment.items.length > 0,
+    ) ??
+      false)
+  );
+}
+
 export function preserveCommittedAssistantTurns(
   next: ChatMessage[],
   pending: ChatMessage[],
@@ -29,17 +48,41 @@ export function preserveCommittedAssistantTurns(
   if (pending.length === 0) {
     return next;
   }
+  const pendingById = new Map(pending.map((message) => [message.id, message]));
+  // A turn can come back from the server PRESENT BUT BARE. The history render
+  // rebuilds the execution trace from that turn's output events, and the
+  // conversation refresh does not wait for them — so the server's copy arrives
+  // carrying the text but no trace, and the "Worked for Ns" anchor and Details
+  // disclosure disappear for a beat before the next rung fills them in. That is
+  // the flicker at the end of a turn that survived preserving absent turns:
+  // this one was never absent.
+  //
+  // While the server's copy is still missing a trace the local one has, the
+  // local copy is the more complete record and keeps rendering. Substituted
+  // whole rather than merged, so the trace keeps its original position relative
+  // to the text — a turn that interleaves tools and prose would be reordered by
+  // grafting segments back on.
+  let substituted = false;
+  const reconciled = next.map((message) => {
+    const local = pendingById.get(message.id);
+    if (!local || !hasExecutionTrace(local) || hasExecutionTrace(message)) {
+      return message;
+    }
+    substituted = true;
+    return local;
+  });
+
   const present = new Set(next.map((message) => message.id));
   // Anything the server now returns is authoritative — its copy carries
   // outputs, provenance and ids the local one never had, so a still-pending
   // turn is only appended while genuinely absent.
   const missing = pending.filter((message) => !present.has(message.id));
   if (missing.length === 0) {
-    return next;
+    return substituted ? reconciled : next;
   }
   // Appended, not spliced: these are always the newest turn in the session, and
   // the refresh that dropped them is by definition missing the tail.
-  return [...next, ...missing];
+  return [...reconciled, ...missing];
 }
 
 /**
@@ -54,6 +97,16 @@ export function settleCommittedAssistantTurns(
   if (pending.length === 0) {
     return pending;
   }
-  const present = new Set(rendered.map((message) => message.id));
-  return pending.filter((message) => !present.has(message.id));
+  const renderedById = new Map(rendered.map((message) => [message.id, message]));
+  return pending.filter((message) => {
+    const server = renderedById.get(message.id);
+    if (!server) {
+      return true;
+    }
+    // Present is not the same as caught up. Settling on id alone is what let
+    // the trace blink out: the local copy was dropped while the server's still
+    // had no execution events, leaving nothing to render the turn's chrome
+    // from. Hold it until the server's copy actually carries the trace.
+    return hasExecutionTrace(message) && !hasExecutionTrace(server);
+  });
 }


### PR DESCRIPTION
Both reported symptoms. They turned out to be unrelated bugs, and the screenshot was what identified the second one — the flash is a **rendering swap**, not a blank.

## 1. The end-of-turn flash

The screenshot shows the turn *with* its "Worked for 5s" anchor and Details disclosure. That chrome is driven by the turn's execution trace, and the trace is what blinks.

The last fix covered a turn going **absent** during the refresh ladder. This is the same turn coming back **present but bare**:

- the history render rebuilds a turn's trace from that turn's **output events**, and the conversation refresh doesn't wait for them
- so a rung lands carrying the turn's *text* but no trace
- `settleCommittedAssistantTurns` dropped the local copy as soon as the **id** appeared
- `preserveCommittedAssistantTurns` wouldn't re-add it — it only restores turns that are **entirely absent**, and this one never was

The complete local copy was replaced by an incomplete server copy, the chrome vanished, the turn collapsed, and the next rung put it back.

Both guards now compare the **trace**, not just the id. Substituted whole rather than merged, so the trace keeps its position relative to the text — grafting segments back on would reorder a turn that interleaves tools and prose.

This is precisely the bug `preserveDisplayedTurnOutputs` already fixes for output cards, one field over: both are re-derived per refresh from a source that lags the conversation.

A turn that never had a trace (a plain text reply runs no tools, gets no chrome) is untouched and settles immediately — so a permanently trace-less turn can't pin the local copy forever.

**Mutation-checked:** reverting either guard fails the two tests that encode the bug.

## 2. Session missing from the sidebar

`useWorkspaceMainSessions` polls at `POLL_INTERVAL_MS = 5_000` with no invalidation on create, and four components each keep their own `useState` — no shared cache to invalidate either. So a session you'd just started had no row for up to 5s.

Creation now broadcasts; every subscriber reloads.

The signal deliberately **carries no session row**: `createAgentSession` returns an `AgentSessionRecordPayload`, which has no `is_active` and so isn't a `MainSessionRecordPayload`. An optimistic insert would mean inventing that field — a row whose state was guessed. Typecheck caught my first version doing exactly that. A reload is one local IPC, so the row still appears at once; it's just the server's row.

## Testing

Desktop suite **613 pass / 0 fail**, typecheck clean.

## Still not fixed

**The canvas blanking when you send into a new session.** Diagnosed, deliberately left:

| line | |
|---|---|
| 7254 | `clearSessionView()` → `setMessages([])` — canvas blanks |
| 7344 | `await createWorkspaceSession(...)` — IPC round trip |
| 7601 | optimistic user message added — content returns |

Empty across an IPC round trip. Fixing it means hoisting the optimistic message above the await (it needs `targetSessionId`, known only after) or splitting `clearSessionView` so bookkeeping resets immediately while the visible list swaps atomically. Both reorder the send critical path in a 393KB component — worth doing, but worth watching run first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)