### PR TITLE
fix(desktop): stop the chat flashing, nudging, and hiding new sessions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -16334,6 +16334,7 @@ async function createAgentSession(
           session_id: payload.session_id ?? undefined,
           kind: payload.kind ?? undefined,
           title: payload.title ?? undefined,
+          first_user_text: payload.first_user_text ?? undefined,
           parent_session_id: payload.parent_session_id ?? undefined,
           project_id: payload.project_id ?? undefined,
           created_by: payload.created_by ?? undefined,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -599,6 +599,9 @@ interface CreateAgentSessionPayload {
 	session_id?: string | null;
 	kind?: string | null;
 	title?: string | null;
+	/** The message about to be sent. Lets the runtime title the session at
+	 *  creation, so the sidebar can list it immediately. */
+	first_user_text?: string | null;
 	parent_session_id?: string | null;
 	created_by?: string | null;
 	/** Owning HolaApp — stamps owning_app_id on the created session. */

--- a/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
+++ b/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
@@ -305,8 +305,6 @@ const mainSessionsChanged = new EventTarget();
 const MAIN_SESSIONS_CHANGED = "main-sessions-changed";
 
 export function notifyMainSessionsChanged(): void {
-  // eslint-disable-next-line no-console
-  console.info("[sessions] broadcast sent");
   mainSessionsChanged.dispatchEvent(new Event(MAIN_SESSIONS_CHANGED));
 }
 
@@ -328,29 +326,13 @@ export function useWorkspaceMainSessions(
       return;
     }
     let cancelled = false;
-    const load = async (reason: "poll" | "broadcast" = "poll") => {
+    const load = async () => {
       setIsLoading(true);
       try {
         const response = await window.electronAPI.workspace.listMainSessions(
           workspaceId,
           appId ?? null,
         );
-        // TEMPORARY diagnostic. A session created from the composer still takes
-        // ~5s to appear, which is equally consistent with "the broadcast never
-        // arrives" and with "it arrives but the session is still untitled and
-        // the sidebar filters it". Those have different fixes and reading the
-        // code has not separated them, so this prints what the server actually
-        // returned at the moment we asked. Remove once answered.
-        if (reason === "broadcast") {
-          // eslint-disable-next-line no-console
-          console.info(
-            "[sessions] broadcast reload ->",
-            (response.sessions ?? [])
-              .slice(0, 3)
-              .map((s) => `${s.session_id.slice(0, 8)}:${JSON.stringify(s.title)}`)
-              .join("  "),
-          );
-        }
         if (!cancelled) {
           setSessions((prev) =>
             reconcileMainSessions(prev, response.sessions ?? []),
@@ -367,39 +349,18 @@ export function useWorkspaceMainSessions(
     void load();
     const timer = window.setInterval(load, POLL_INTERVAL_MS);
 
-    // Reload now, then twice more shortly after.
-    //
-    // A single shot has to assume the session is already listable at the moment
-    // we ask, and that assumption has been wrong once already: broadcasting at
-    // creation reloaded a list in which the session was still untitled, and the
-    // sidebar hides untitled sessions. The queue call is supposed to have set
-    // the title by the time it returns, but "supposed to" is what the last two
-    // attempts rested on. These follow-ups bound the worst case at ~1.2s
-    // whatever the real timing turns out to be, instead of falling back to the
-    // 5s poll.
-    const followUps: number[] = [];
+    // One reload is enough: the session is titled at creation now, so it is
+    // listable by the time this fires. The staggered follow-ups that used to be
+    // here were bounding a delay whose real cause was the missing title, and
+    // kept nine list calls per send alive for nothing once that was fixed.
     const onChanged = () => {
-      // eslint-disable-next-line no-console
-      console.info("[sessions] broadcast received");
-      void load("broadcast");
-      for (const delay of [400, 1200]) {
-        followUps.push(
-          window.setTimeout(() => {
-            if (!cancelled) {
-              void load("broadcast");
-            }
-          }, delay),
-        );
-      }
+      void load();
     };
     mainSessionsChanged.addEventListener(MAIN_SESSIONS_CHANGED, onChanged);
 
     return () => {
       cancelled = true;
       window.clearInterval(timer);
-      for (const id of followUps) {
-        window.clearTimeout(id);
-      }
       mainSessionsChanged.removeEventListener(MAIN_SESSIONS_CHANGED, onChanged);
     };
   }, [workspaceId, appId, activeOrgId]);

--- a/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
+++ b/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
@@ -305,6 +305,8 @@ const mainSessionsChanged = new EventTarget();
 const MAIN_SESSIONS_CHANGED = "main-sessions-changed";
 
 export function notifyMainSessionsChanged(): void {
+  // eslint-disable-next-line no-console
+  console.info("[sessions] broadcast sent");
   mainSessionsChanged.dispatchEvent(new Event(MAIN_SESSIONS_CHANGED));
 }
 
@@ -326,13 +328,29 @@ export function useWorkspaceMainSessions(
       return;
     }
     let cancelled = false;
-    const load = async () => {
+    const load = async (reason: "poll" | "broadcast" = "poll") => {
       setIsLoading(true);
       try {
         const response = await window.electronAPI.workspace.listMainSessions(
           workspaceId,
           appId ?? null,
         );
+        // TEMPORARY diagnostic. A session created from the composer still takes
+        // ~5s to appear, which is equally consistent with "the broadcast never
+        // arrives" and with "it arrives but the session is still untitled and
+        // the sidebar filters it". Those have different fixes and reading the
+        // code has not separated them, so this prints what the server actually
+        // returned at the moment we asked. Remove once answered.
+        if (reason === "broadcast") {
+          // eslint-disable-next-line no-console
+          console.info(
+            "[sessions] broadcast reload ->",
+            (response.sessions ?? [])
+              .slice(0, 3)
+              .map((s) => `${s.session_id.slice(0, 8)}:${JSON.stringify(s.title)}`)
+              .join("  "),
+          );
+        }
         if (!cancelled) {
           setSessions((prev) =>
             reconcileMainSessions(prev, response.sessions ?? []),
@@ -361,12 +379,14 @@ export function useWorkspaceMainSessions(
     // 5s poll.
     const followUps: number[] = [];
     const onChanged = () => {
-      void load();
+      // eslint-disable-next-line no-console
+      console.info("[sessions] broadcast received");
+      void load("broadcast");
       for (const delay of [400, 1200]) {
         followUps.push(
           window.setTimeout(() => {
             if (!cancelled) {
-              void load();
+              void load("broadcast");
             }
           }, delay),
         );

--- a/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
+++ b/apps/desktop/src/components/layout/shell/useWorkspaceLists.ts
@@ -349,14 +349,37 @@ export function useWorkspaceMainSessions(
     void load();
     const timer = window.setInterval(load, POLL_INTERVAL_MS);
 
+    // Reload now, then twice more shortly after.
+    //
+    // A single shot has to assume the session is already listable at the moment
+    // we ask, and that assumption has been wrong once already: broadcasting at
+    // creation reloaded a list in which the session was still untitled, and the
+    // sidebar hides untitled sessions. The queue call is supposed to have set
+    // the title by the time it returns, but "supposed to" is what the last two
+    // attempts rested on. These follow-ups bound the worst case at ~1.2s
+    // whatever the real timing turns out to be, instead of falling back to the
+    // 5s poll.
+    const followUps: number[] = [];
     const onChanged = () => {
       void load();
+      for (const delay of [400, 1200]) {
+        followUps.push(
+          window.setTimeout(() => {
+            if (!cancelled) {
+              void load();
+            }
+          }, delay),
+        );
+      }
     };
     mainSessionsChanged.addEventListener(MAIN_SESSIONS_CHANGED, onChanged);
 
     return () => {
       cancelled = true;
       window.clearInterval(timer);
+      for (const id of followUps) {
+        window.clearTimeout(id);
+      }
       mainSessionsChanged.removeEventListener(MAIN_SESSIONS_CHANGED, onChanged);
     };
   }, [workspaceId, appId, activeOrgId]);

--- a/apps/desktop/src/components/panes/ChatPane.test.mjs
+++ b/apps/desktop/src/components/panes/ChatPane.test.mjs
@@ -1011,7 +1011,10 @@ test("chat pane routes immediate sends through the newer pending session request
   );
   assert.match(
     source,
-    /if \(pendingSessionTarget\) \{\s*consumeSessionOpenRequest\(pendingSessionTarget\.requestKey\);\s*clearSessionView\(\);[\s\S]*setActiveSession\(pendingSessionTarget\.sessionId\);[\s\S]*draftParentSessionIdRef\.current = pendingSessionTarget\.parentSessionId;\s*setActiveSession\(null\);/,
+    // clearSessionView now defers the blank here (keepMessages) so the canvas
+    // is not empty for the whole session-creation round trip; the conversation
+    // is swapped out when the send's own first message arrives.
+    /if \(pendingSessionTarget\) \{\s*consumeSessionOpenRequest\(pendingSessionTarget\.requestKey\);[\s\S]*clearSessionView\(\{ keepMessages: true \}\);[\s\S]*setActiveSession\(pendingSessionTarget\.sessionId\);[\s\S]*draftParentSessionIdRef\.current = pendingSessionTarget\.parentSessionId;\s*setActiveSession\(null\);/,
   );
   assert.match(
     source,
@@ -1496,9 +1499,12 @@ test("chat pane keeps the current stream attached while queueing a follow-up inp
     source,
     /const queueOntoActiveRun =[\s\S]*\(isResponding[\s\S]*Boolean\(activeStreamIdRef\.current\)[\s\S]*Boolean\(pendingInputIdRef\.current\)\)[\s\S]*targetSessionId === activeSessionIdRef\.current;/,
   );
+  // The optimistic user message now either appends or REPLACES: sending into a
+  // new session holds the outgoing conversation on screen (rather than blanking
+  // the canvas for the whole session-creation round trip) and swaps it out here.
   assert.match(
     source,
-    /if \(!queueOntoActiveRun\) \{[\s\S]*setMessages\(\(prev\) => \[\.\.\.prev, userMessage\]\);[\s\S]*\}/,
+    /if \(!queueOntoActiveRun\) \{[\s\S]*setMessages\(\(prev\) => \(swapping \? \[userMessage\] : \[\.\.\.prev, userMessage\]\)\);[\s\S]*\}/,
   );
   assert.doesNotMatch(source, /eventType: "stream_open_prequeue"/);
   assert.match(

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/index.tsx
@@ -426,7 +426,19 @@ function AssistantTurnComponent({
         ) : null}
       </div>
 
-      {showActionsMenu || (showAvatar && timeLabel) ? (
+      {/* Reserved while the turn is live. `showActionsMenu` is
+          `hasAnyContent && !live` and the timestamp only exists once the turn
+          is committed, so this whole 28px row (mt-1 + h-6) used to APPEAR at
+          completion — growing the turn the instant the agent stopped typing and
+          nudging the conversation. The row now occupies its space for the
+          turn's whole life and merely fills in, so nothing moves.
+
+          The condition mirrors the settled one: reserve exactly when the
+          settled turn will render this row, or the reservation would itself
+          become a shift in the other direction. */}
+      {showActionsMenu ||
+      (showAvatar && timeLabel) ||
+      (live && hasAnyContent) ? (
         <div className="mt-1 flex h-6 items-center gap-2">
           {showAvatar && timeLabel ? (
             <span className="select-none text-xs leading-none text-muted-foreground tabular-nums">

--- a/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnFooterReservation.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/AssistantTurn/turnFooterReservation.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * The turn must not grow when it finishes.
+ *
+ * The footer row (timestamp + actions) is `mt-1 h-6` — 28px — and its two
+ * conditions are both false while streaming: `showActionsMenu` is
+ * `hasAnyContent && !live`, and the timestamp only exists once the turn is
+ * committed. So the row APPEARED at completion, growing the turn the instant
+ * the agent stopped typing and nudging the conversation.
+ *
+ * Same class as the "Worked for Ns" anchor removed alongside this: anything
+ * that exists in only one of the two states moves the layout on the transition.
+ * The anchor could simply go; the timestamp and actions are worth keeping, so
+ * the row is reserved instead and merely fills in.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, "index.tsx"), "utf-8");
+
+test("the footer row is reserved while the turn is live", () => {
+  assert.match(
+    source,
+    /\{showActionsMenu \|\|\s*\(showAvatar && timeLabel\) \|\|\s*\(live && hasAnyContent\) \?/,
+    "a live turn with content must still render the footer row, or it appears at completion and grows the turn",
+  );
+});
+
+test("the reservation matches the settled condition", () => {
+  // showActionsMenu is `hasAnyContent && !live`, so a settled turn renders the
+  // row exactly when it has content. Reserving on `live && hasAnyContent` is
+  // the same predicate on the other side of the flip — reserving more widely
+  // would make the row VANISH at completion, a shift in the other direction.
+  assert.match(
+    source,
+    /const showActionsMenu = hasAnyContent && !live;/,
+    "the settled condition changed; the reservation above must be re-derived from it",
+  );
+});
+
+test("the row keeps a fixed height so filling it cannot resize the turn", () => {
+  assert.match(
+    source,
+    /\(live && hasAnyContent\) \? \(\s*<div className="mt-1 flex h-6 items-center gap-2">/,
+    "the reserved row must have an explicit height, or an empty row collapses",
+  );
+});

--- a/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
@@ -246,6 +246,17 @@ export function ConversationTurns<Message extends ChatMessage>({
 
   if (liveAssistantTurn) {
     const liveTurnKey = liveAssistantTurn.id ?? "__live_assistant_turn__";
+    // Mirrors the spacing the committed turn will carry. Getting this wrong is
+    // a shift of exactly one `mt-2` (8px) at completion — the residual nudge
+    // left after the remount was fixed, because the live wrapper had no spacing
+    // and the committed one does.
+    const livePrevious = messages[messages.length - 1];
+    const liveIsFirstInAssistantGroup =
+      messages.length === 0 || livePrevious?.role === "user";
+    const liveIsGroupedContinuation =
+      livePrevious?.role === "assistant" && !liveIsFirstInAssistantGroup;
+    const liveSpacingClassName =
+      messages.length > 0 && !liveIsGroupedContinuation ? "mt-2" : "";
     renderedTurns.push(
       // Same key AND the same wrapper element the turn will carry once
       // committed, so React reconciles the live node into the committed one
@@ -262,11 +273,11 @@ export function ConversationTurns<Message extends ChatMessage>({
       <div
         key={liveTurnKey}
         data-message-id={liveAssistantTurn.id ?? undefined}
-        // No wrapper class: the live turn is not a full Message, and this
-        // decorator (search highlight and friends) only applies to committed
-        // ones. Reconciliation turns on element type and key, not className,
-        // so leaving it off costs nothing here.
-        className={undefined}
+        // Spacing only. The per-message decorator (search highlight and
+        // friends) needs a full Message and does not apply to a live turn, but
+        // the SPACING must match what the committed turn will have or the turn
+        // moves by 8px the moment it settles.
+        className={liveSpacingClassName || undefined}
       >
         <AssistantTurn
           label={assistantLabel}
@@ -282,10 +293,7 @@ export function ConversationTurns<Message extends ChatMessage>({
           onToggleTraceStep={onToggleTraceStep}
           onLinkClick={onLinkClick}
           onLocalLinkClick={onLocalLinkClick}
-          showAvatar={
-            messages.length === 0 ||
-            messages[messages.length - 1]?.role === "user"
-          }
+          showAvatar={liveIsFirstInAssistantGroup}
           workspaceId={workspaceId ?? null}
           harnessId={harnessId}
           assistantAvatar={assistantAvatar}

--- a/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/ConversationTurns.tsx
@@ -245,11 +245,29 @@ export function ConversationTurns<Message extends ChatMessage>({
   });
 
   if (liveAssistantTurn) {
+    const liveTurnKey = liveAssistantTurn.id ?? "__live_assistant_turn__";
     renderedTurns.push(
-      // Same key the turn will carry once committed, so React reconciles the
-      // live node into the committed one instead of unmount+remount (which
-      // replays the entrance animation — the completion "flicker").
-      <Fragment key={liveAssistantTurn.id ?? "__live_assistant_turn__"}>
+      // Same key AND the same wrapper element the turn will carry once
+      // committed, so React reconciles the live node into the committed one
+      // instead of unmount+remount.
+      //
+      // The key alone was not enough, which is why the completion flicker
+      // outlived the comment that used to sit here: a keyed Fragment and a
+      // keyed <div> are different element TYPES, and React tears down and
+      // rebuilds across a type change no matter what the key says. The remount
+      // replayed `animate-in fade-in-0 slide-in-from-bottom-1` on the turn —
+      // a fade and a slide, which is the "blink + nudge" at the end of a turn.
+      //
+      // Matching the wrapper is what makes the key do its job.
+      <div
+        key={liveTurnKey}
+        data-message-id={liveAssistantTurn.id ?? undefined}
+        // No wrapper class: the live turn is not a full Message, and this
+        // decorator (search highlight and friends) only applies to committed
+        // ones. Reconciliation turns on element type and key, not className,
+        // so leaving it off costs nothing here.
+        className={undefined}
+      >
         <AssistantTurn
           label={assistantLabel}
           mode={assistantMode}
@@ -277,7 +295,7 @@ export function ConversationTurns<Message extends ChatMessage>({
           status={liveAssistantTurn.status ?? ""}
           footerAccessory={liveAssistantTurn.footerAccessory ?? null}
         />
-      </Fragment>,
+      </div>,
     );
   }
 

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -3804,6 +3804,10 @@ export function ChatPane({
   /** Assistant turns committed locally that the server has not returned yet.
    *  The assistant-side counterpart of pendingOptimisticUserMessagesRef. */
   const pendingCommittedAssistantTurnsRef = useRef<ChatMessage[]>([]);
+  // Set when a send has deferred blanking the canvas because it intends to
+  // replace the conversation with its own first message. Cleared by that swap,
+  // or by settlePendingSessionSwap if the send never gets that far.
+  const pendingSessionSwapRef = useRef(false);
   const [sessionOutputs, setSessionOutputs] = useState<
     WorkspaceOutputRecordPayload[]
   >([]);
@@ -4428,8 +4432,30 @@ export function ChatPane({
     );
   }
 
-  function clearSessionView() {
+  /**
+   * `keepMessages` leaves the visible list alone while resetting everything
+   * else. Used when we are about to REPLACE the conversation rather than merely
+   * leave it: blanking here and then awaiting session creation left the canvas
+   * empty across an IPC round trip, which is the flash when you send into a new
+   * session. The caller swaps the list in one step instead, once it has the
+   * first message to show.
+   *
+   * Every other caller still blanks, because they genuinely have nothing to put
+   * in its place (workspace switch, blank draft, session delete).
+   */
+  /** Blank a conversation that was held over for a swap that never happened. */
+  function settlePendingSessionSwap() {
+    if (!pendingSessionSwapRef.current) {
+      return;
+    }
+    pendingSessionSwapRef.current = false;
     setMessages([]);
+  }
+
+  function clearSessionView(options: { keepMessages?: boolean } = {}) {
+    if (!options.keepMessages) {
+      setMessages([]);
+    }
     // Scoped to the session it was committed in — leaving it set would splice a
     // turn from the previous conversation into the next one.
     pendingCommittedAssistantTurnsRef.current = [];
@@ -7259,7 +7285,12 @@ export function ChatPane({
 
     if (pendingSessionTarget) {
       consumeSessionOpenRequest(pendingSessionTarget.requestKey);
-      clearSessionView();
+      // Hold the outgoing conversation on screen until this send has its own
+      // first message to replace it with. Creating the session is an IPC round
+      // trip, and blanking before it leaves the canvas empty for the whole of
+      // it. The swap happens where the optimistic user message is appended.
+      pendingSessionSwapRef.current = true;
+      clearSessionView({ keepMessages: true });
       if (pendingSessionTarget.mode === "session") {
         setActiveSession(pendingSessionTarget.sessionId);
       } else {
@@ -7340,6 +7371,10 @@ export function ChatPane({
         }
       } catch (error) {
         setChatErrorMessage(normalizeErrorMessage(error));
+        // The swap never happened, so the held-over conversation belongs to a
+        // session we are no longer in. Blank it now rather than leave it under
+        // the wrong session.
+        settlePendingSessionSwap();
         return;
       }
     }
@@ -7388,6 +7423,7 @@ export function ChatPane({
     }
     if (!targetSessionId) {
       setChatErrorMessage("No active session found for this workspace.");
+      settlePendingSessionSwap();
       return;
     }
     blankDraftActiveRef.current = false;
@@ -7617,8 +7653,15 @@ export function ChatPane({
       };
 
       shouldAutoScrollRef.current = true;
+      // A pending swap means the list still holds the PREVIOUS session's
+      // conversation, kept there so the canvas never went blank. Consumed
+      // unconditionally: queueing onto an active run takes the branch below
+      // that adds no message, and a flag left set would make the NEXT send
+      // replace a conversation it should have appended to.
+      const swapping = pendingSessionSwapRef.current;
+      pendingSessionSwapRef.current = false;
       if (!queueOntoActiveRun) {
-        setMessages((prev) => [...prev, userMessage]);
+        setMessages((prev) => (swapping ? [userMessage] : [...prev, userMessage]));
         updatePendingOptimisticUserMessagesState((current) => [
           ...current.filter(
             (item) =>

--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -4950,6 +4950,7 @@ export function ChatPane({
     parentSessionId?: string | null,
     projectId?: string | null,
     owningAppId?: string | null,
+    firstUserText?: string | null,
   ): Promise<string | null> {
     const created = await window.electronAPI.workspace.createAgentSession({
       workspace_id: workspaceId,
@@ -4958,6 +4959,13 @@ export function ChatPane({
       project_id: projectId ?? null,
       created_by: "workspace_user",
       app_id: owningAppId ?? null,
+      // Titles the session at creation. The sidebar hides titleless sessions as
+      // empty placeholders, and the title used to be written only when the
+      // input was queued — so the row appeared not when the session was created
+      // but whenever the send finished assembling, seconds later. The runtime
+      // derives it, so the rules for attachments and image-only sends stay in
+      // one place.
+      first_user_text: firstUserText?.trim() || null,
     });
     const sessionId = created.session.session_id.trim();
     if (sessionId) {
@@ -7390,6 +7398,7 @@ export function ChatPane({
         draftParentSessionId,
         selectedChatProjectId,
         owningAppId,
+        text,
       );
       if (targetSessionId) {
         draftParentSessionIdRef.current = null;

--- a/apps/desktop/src/components/panes/ChatPane/liveTurnReconciliation.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/liveTurnReconciliation.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * The live turn must reconcile into the committed one, not be replaced by it.
+ *
+ * When a turn finishes, the streaming node is dropped and the committed node
+ * takes its place. If React tears the first down and builds the second, the
+ * turn's entrance animation — `animate-in fade-in-0 slide-in-from-bottom-1` —
+ * replays: a fade and a slide, which is the blink-and-nudge at the end of every
+ * turn.
+ *
+ * The key was already matched for exactly this reason. It was not enough,
+ * because the live turn was a keyed Fragment and the committed turn a keyed
+ * <div>: React tears down across an element TYPE change no matter what the key
+ * says. Both sides must be the same element.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, "ConversationTurns.tsx"), "utf-8");
+
+test("the live turn is wrapped in the same element type as a committed turn", () => {
+  const live = /if \(liveAssistantTurn\) \{[\s\S]*?renderedTurns\.push\(([\s\S]*?)<AssistantTurn/.exec(
+    source,
+  );
+  assert.ok(live, "could not find the live turn's wrapper");
+  assert.match(
+    live[1],
+    /<div\b/,
+    "the live turn must be wrapped in a <div>, matching the committed turn; a Fragment is a different element type and forces a remount",
+  );
+  assert.doesNotMatch(
+    live[1],
+    /<Fragment\b/,
+    "a keyed Fragment cannot reconcile into a keyed <div>",
+  );
+});
+
+test("the live turn carries the key it will have once committed", () => {
+  assert.match(
+    source,
+    /const liveTurnKey = liveAssistantTurn\.id \?\? "__live_assistant_turn__";/,
+    "the live turn's key must be the committed message id",
+  );
+  assert.match(source, /key=\{liveTurnKey\}/);
+});
+
+test("committed turns still key on the message id", () => {
+  // The other half of the pair. If this changes, the live key above has to
+  // change with it or they stop matching and the remount returns.
+  assert.match(
+    source,
+    /key=\{message\.id\}/,
+    "committed turns must key on message.id for the live key to match",
+  );
+});

--- a/apps/desktop/src/components/panes/ChatPane/liveTurnReconciliation.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/liveTurnReconciliation.test.ts
@@ -57,3 +57,31 @@ test("committed turns still key on the message id", () => {
     "committed turns must key on message.id for the live key to match",
   );
 });
+
+test("the live turn carries the spacing its committed form will have", () => {
+  // Reconciling the element was not enough on its own: committed turns get an
+  // `mt-2` spacing class and the live wrapper had none, so the turn still moved
+  // 8px the moment it settled. The live spacing has to be derived from the same
+  // grouping rules as the committed one.
+  assert.match(
+    source,
+    /const liveIsGroupedContinuation =\s*livePrevious\?\.role === "assistant" && !liveIsFirstInAssistantGroup;/,
+    "live grouping must mirror the committed isGroupedContinuation",
+  );
+  assert.match(
+    source,
+    /const liveSpacingClassName =\s*messages\.length > 0 && !liveIsGroupedContinuation \? "mt-2" : "";/,
+    "live spacing must mirror the committed spacingClassName",
+  );
+  assert.match(
+    source,
+    /className=\{liveSpacingClassName \|\| undefined\}/,
+    "the live wrapper must apply that spacing",
+  );
+});
+
+test("avatar and spacing agree on where the assistant group starts", () => {
+  // showAvatar and the spacing both hang off the same predicate. Computing them
+  // separately is how they drift apart.
+  assert.match(source, /showAvatar=\{liveIsFirstInAssistantGroup\}/);
+});

--- a/apps/desktop/src/components/panes/ChatPane/sessionSwap.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/sessionSwap.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * Sending into a new session must not blank the canvas.
+ *
+ * The send path used to call clearSessionView() — setMessages([]) — and only
+ * rebuild the view after awaiting session creation, so the canvas sat empty
+ * across an IPC round trip. That is the flash when you start a new chat, and it
+ * ends at the same moment the new row appears in the sidebar because both hang
+ * off the same queue response.
+ *
+ * The conversation is now held on screen and replaced in one step by the send's
+ * own first message. Structural, in a `.test.ts` deliberately: `test:unit`
+ * globs `.test.ts` / `.test.tsx`, so a guard written as `.mjs` under src/ would
+ * never run.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(here, "index.tsx"), "utf-8");
+
+test("the send path defers blanking instead of clearing across the await", () => {
+  const sendClear = /consumeSessionOpenRequest\(pendingSessionTarget\.requestKey\);[\s\S]{0,600}?clearSessionView\((\{[^)]*\})?\)/.exec(
+    source,
+  );
+  assert.ok(sendClear, "could not find the send path's clearSessionView call");
+  assert.match(
+    sendClear[0],
+    /keepMessages:\s*true/,
+    "the send path must keep the conversation visible; blanking here empties the canvas for the whole session-creation round trip",
+  );
+});
+
+test("every other clearSessionView still blanks", () => {
+  // Workspace switch, blank draft and session delete genuinely have nothing to
+  // put in place of the conversation. Only the send path defers.
+  const keepers = source.match(/clearSessionView\(\{[^}]*keepMessages/g) ?? [];
+  assert.equal(
+    keepers.length,
+    1,
+    `only the send path may keep messages, found ${keepers.length}`,
+  );
+});
+
+test("the held conversation is replaced wholesale, not appended to", () => {
+  // The list still holds the PREVIOUS session's messages. Appending would show
+  // the old conversation with the new message stuck on the end.
+  assert.match(
+    source,
+    /setMessages\(\(prev\) => \(swapping \? \[userMessage\] : \[\.\.\.prev, userMessage\]\)\)/,
+    "the optimistic user message must replace the held conversation when swapping",
+  );
+});
+
+test("the swap flag is consumed even when no message is added", () => {
+  // Queueing onto an active run adds no message. A flag left set there would
+  // make the NEXT send replace a conversation it should have appended to.
+  const consume = /const swapping = pendingSessionSwapRef\.current;\s*\n\s*pendingSessionSwapRef\.current = false;\s*\n\s*if \(!queueOntoActiveRun\)/.test(
+    source,
+  );
+  assert.ok(
+    consume,
+    "the flag must be read and cleared before the queueOntoActiveRun branch, not inside it",
+  );
+});
+
+test("a send that fails before the swap does not strand the old conversation", () => {
+  // Both early exits between deferring the blank and performing the swap leave
+  // the previous session's messages on screen under a session we are no longer
+  // in, so each must settle the pending swap.
+  const exits = source.match(/settlePendingSessionSwap\(\);/g) ?? [];
+  assert.ok(
+    exits.length >= 2,
+    `expected both early exits to settle the swap, found ${exits.length}`,
+  );
+  assert.match(
+    source,
+    /function settlePendingSessionSwap\(\)[\s\S]{0,300}?setMessages\(\[\]\)/,
+    "settling must blank the held conversation",
+  );
+});

--- a/apps/desktop/src/components/panes/ChatPane/sessionTitledAtCreation.test.ts
+++ b/apps/desktop/src/components/panes/ChatPane/sessionTitledAtCreation.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * A session must be listable the moment it is created.
+ *
+ * The sidebar hides titleless sessions as empty placeholders, and the title was
+ * written only by the queue-input route — so the row appeared not when the
+ * session was created but whenever the send finished assembling and queueing,
+ * seconds later. Measured in the running app: the reload right after creation
+ * came back `5630b58c:null`, and only the reload after the queue call returned
+ * `5630b58c:"hey"`, which is exactly when the row showed up.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const chatPane = readFileSync(path.join(here, "index.tsx"), "utf-8");
+
+test("the send passes its first message when creating the session", () => {
+  assert.match(
+    chatPane,
+    /first_user_text: firstUserText\?\.trim\(\) \|\| null,/,
+    "createWorkspaceSession must forward the text so the runtime can title the session",
+  );
+  assert.match(
+    chatPane,
+    /createWorkspaceSession\(\s*selectedWorkspace\.id,\s*draftParentSessionId,\s*selectedChatProjectId,\s*owningAppId,\s*text,\s*\)/,
+    "the send path must pass the composer text",
+  );
+});
+
+test("the title is derived by the runtime, not the client", () => {
+  // sessionTitleFromFirstUserInput handles attachments and image-only sends as
+  // well as text. Duplicating that here would drift, and because the queue
+  // route leaves an existing title alone, any drift would be permanent.
+  assert.doesNotMatch(
+    chatPane,
+    /sessionTitleFromFirstUserInput|normalizedSessionTitleSnippet/,
+    "the client must not derive session titles itself",
+  );
+});

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -1150,6 +1150,9 @@ declare global {
 		session_id?: string | null;
 		kind?: string | null;
 		title?: string | null;
+		/** The message about to be sent. Lets the runtime title the session at
+		 *  creation, so the sidebar can list it immediately. */
+		first_user_text?: string | null;
 		parent_session_id?: string | null;
 		project_id?: string | null;
 		created_by?: string | null;

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -10657,7 +10657,23 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
       kind:
         canonicalAgentSessionKind(optionalString(request.body.kind)) ??
         inferredSessionKind(workspace, sessionId),
-      title: nullableString(request.body.title) ?? null,
+      // An explicit title wins. Otherwise derive one from the message the
+      // caller is about to send, using the SAME function the queue route uses,
+      // so a session is listable from birth rather than from whenever its first
+      // input lands.
+      //
+      // The sidebar hides titleless sessions as empty placeholders, and the
+      // title used to be written only by the queue route — so the row for a
+      // session appeared not when it was created but whenever the send finished
+      // assembling and queueing, which was seconds later. Deriving it here
+      // rather than in the client keeps one implementation of the rules for
+      // attachments and image-only sends.
+      title:
+        nullableString(request.body.title) ??
+        sessionTitleFromFirstUserInput(
+          optionalString(request.body.first_user_text) ?? "",
+          [],
+        ),
       parentSessionId: nullableString(request.body.parent_session_id) ?? null,
       projectId: nullableString(request.body.project_id) ?? null,
       harnessId: resolvedHarnessId,


### PR DESCRIPTION
Three reported symptoms, which turned out to be **five distinct causes**. Every one was found by running it and reading logs — several of my earlier guesses were wrong, and the commit history keeps them visible rather than tidied away.

## 1. Canvas blank when starting a chat

`clearSessionView()` → `setMessages([])` fired *before* awaiting session creation, so the canvas sat empty across an IPC round trip.

`clearSessionView` gained a `keepMessages` option used only by the send path: the outgoing conversation stays on screen and is replaced wholesale by the send's own first message. Every other caller still blanks — workspace switch, blank draft, session delete genuinely have nothing to put in its place.

## 2. "Worked for Ns" appearing at completion

The anchor was absent while the answer streamed and present once settled, inserting a row into a laid-out turn. It's a *presence* rule, not a labelling one — anything existing in only one of the two states moves the layout on the transition. Removed for turns that end with their answer; error and awaiting-user statuses untouched.

## 3. The turn's footer appearing at completion

Timestamp + actions live in a `mt-1 h-6` row whose two conditions are both false while streaming (`showActionsMenu` is `hasAnyContent && !live`; the timestamp only exists once committed). The row is now reserved for the turn's whole life and merely fills in.

## 4. Blink + nudge — a remount, not a layout change

The turn was torn down and rebuilt, replaying `animate-in fade-in-0 slide-in-from-bottom-1`: the fade is the blink, the slide is the nudge.

Someone had already tried to fix this and the comment was still there — *"Same key the turn will carry once committed, so React reconciles the live node…"*. The key was right; the **element** wasn't. Committed turns render in a keyed `<div>`, the live turn was a keyed `<Fragment>`, and React tears down across an element *type* change however well the keys match. Matching the wrapper is what makes that key work.

A smaller shift survived that: committed turns carry an `mt-2` class the live wrapper lacked, so the turn moved 8px on settling. The live wrapper now derives its spacing from the same grouping rules, with `showAvatar` reading the same predicate.

## 5. New session missing from the sidebar for ~5s

Two earlier attempts fixed *refresh timing*, which was never what was slow. Instrumentation settled it:

```
broadcast reload -> 5630b58c:null     ← right after creation
broadcast reload -> 5630b58c:"hey"    ← after the queue call → row appears
```

Both broadcasts fire and are received. The sidebar hides titleless sessions, and the title was written only by the queue route — so the row waited on the send finishing its assembly, seconds later.

The create route now derives the title too, from a `first_user_text` the send passes. **Derived server-side with the same function the queue route uses** — duplicating the attachment and image-only rules client-side would drift, and since the queue route leaves an existing title alone, that drift would be permanent.

The staggered follow-up reloads added mid-investigation are removed with the diagnostics: with the title fixed at source, one reload suffices, and keeping them left nine list calls per send running for nothing.

## Testing

Desktop **631 pass**, api-server **1162 pass**, both typecheck clean. All five behaviours confirmed fixed in the running app.

Two source-snapshot assertions in `ChatPane.test.mjs` pinned call-site structure that legitimately changed, and are updated rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)