### PR TITLE
fix(runtime): surface end-of-turn compaction failures in runtime.log

### DIFF
--- a/runtime/api-server/src/compaction-visibility.test.ts
+++ b/runtime/api-server/src/compaction-visibility.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+/**
+ * A failed end-of-turn compaction has to be readable somewhere.
+ *
+ * Compaction runs after the terminal event and its failure does not fail the
+ * run, so pi's warning went to the ts-runner stderr this module "buffers and
+ * only surfaces on failure" — written where nobody could read it. The cost is
+ * not cosmetic: a failed compaction leaves the session uncompacted, so the next
+ * turn is larger and likelier to fail the same way, and the first anyone learns
+ * of it is a turn that blows the context window.
+ *
+ * The [ttft] line is the channel that does reach runtime.log on a successful
+ * turn, which is why it carries this.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.join(here, "runner-worker.ts"), "utf-8");
+
+test("compaction failures are scraped from the live stderr stream", () => {
+  // Scraped as chunks arrive, not from the buffered result: that result is
+  // discarded on a successful run, which is exactly the case in question.
+  assert.match(
+    source,
+    /for await \(const chunk of stderr\)[\s\S]{0,600}?pi end-of-turn compaction failed/,
+    "the marker must be matched inside the stderr consumer loop",
+  );
+});
+
+test("the failure reaches the [ttft] line", () => {
+  assert.match(
+    source,
+    /compactionFailure \? ` compaction_failed=/,
+    "a compaction failure must appear on the line that lands in runtime.log",
+  );
+});
+
+test("a healthy turn stays quiet", () => {
+  // Only failures are reported. `compaction=ok` on every turn would be noise,
+  // and its absence is the normal case.
+  assert.doesNotMatch(
+    source,
+    /compaction_failed=\$\{[^}]*\}`\s*\)/,
+    "the field must be conditional, not unconditional",
+  );
+  assert.match(
+    source,
+    /let compactionFailure: string \| null = null;/,
+    "null means no failure was seen this turn",
+  );
+});
+
+test("the captured text is bounded", () => {
+  // pi's message embeds an upstream error that could be arbitrarily long; an
+  // unbounded slice of it would run away with the log line.
+  assert.match(source, /\.slice\(0, 200\)/);
+});

--- a/runtime/api-server/src/runner-worker.ts
+++ b/runtime/api-server/src/runner-worker.ts
@@ -787,11 +787,34 @@ export async function executeRunnerRequest(
   };
   options.signal?.addEventListener("abort", abortChild, { once: true });
 
+  // End-of-turn compaction failures are reported here, scraped from the stream
+  // as it arrives rather than from the buffered result.
+  //
+  // Compaction runs AFTER the terminal event and its failure does not fail the
+  // run, so pi's warning went to a stream that is "buffered by us and only
+  // surfaced on failure" (see above) — a signal written where nobody could read
+  // it. The consequence is not cosmetic: a failed compaction leaves the session
+  // uncompacted, so the next turn is larger and likelier to fail the same way,
+  // and the first anyone learns of it is a turn that blows the context window.
+  //
+  // Scraped rather than plumbed because the failure happens after the terminal
+  // event, by which point the event channel is closed and there is nothing left
+  // to attach it to.
+  let compactionFailure: string | null = null;
   const stderrPromise = (async () => {
     const chunks: Buffer[] = [];
     for await (const chunk of stderr) {
       resetIdleTimeout();
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      chunks.push(buffer);
+      if (compactionFailure === null) {
+        const match = /pi end-of-turn compaction failed[^\n]*/.exec(
+          buffer.toString("utf-8"),
+        );
+        if (match) {
+          compactionFailure = match[0].slice(0, 200);
+        }
+      }
     }
     return Buffer.concat(chunks).toString("utf-8").trim();
   })();
@@ -947,7 +970,10 @@ export async function executeRunnerRequest(
         (ttftInputTokens && ttftInputTokens > 0 && ttftCachedInputTokens !== null
           ? ` cache_hit=${Math.round((ttftCachedInputTokens / ttftInputTokens) * 100)}%`
           : "") +
-        (setupBreakdown ? ` setup=[${setupBreakdown}]` : ""),
+        (setupBreakdown ? ` setup=[${setupBreakdown}]` : "") +
+        // Only on failure: a compaction=ok on every line would be noise, and
+        // the absence of this is the normal case.
+        (compactionFailure ? ` compaction_failed=${JSON.stringify(compactionFailure)}` : ""),
     );
   }
 


### PR DESCRIPTION
I claimed this failure was "now visible in logs" after the earlier compaction work. **It wasn't.** This module says why in its own comment:

> *"the ts-runner subprocess stderr is buffered by us and only surfaced on failure, so a log there is invisible on successful turns"*

A failed compaction doesn't fail the run — so pi's warning went to a stream nobody could read. Making the outcome a return value in #525 made it *assertable in tests*; it did nothing for production, where the only signal was still that warning.

## Why the silence matters

A failed compaction leaves the session uncompacted, so the next turn is larger, its summarization is larger, and it's likelier to fail the same way. The first anyone learns of it is a turn that blows the context window — with nothing in the logs connecting the two.

## The fix

The failure is scraped off the stderr stream as chunks arrive and appended to the `[ttft]` line, which *does* reach `runtime.log` on a successful turn — the same reasoning that put the TTFT breakdown there.

Scraped rather than plumbed through an event because compaction runs **after** the terminal event, by which point the event channel is closed and there's nothing left to attach it to.

Only failures are reported (a `compaction=ok` on every line would be noise), and the captured text is capped at 200 chars since it embeds an upstream error of unbounded length.

## Why now

I ran an experiment to characterise the ~570k-token compaction timeout and it was invalid — the saved session was already post-compaction, and `keepRecentTokens` is 20,000 with summarization at message granularity, so its single 722k-character trailing message couldn't be split and there was nothing left to summarize. Five trials, no summarization call made.

The honest conclusion was to stop and wait for a real occurrence. That plan only works if a real occurrence is actually recorded — which it wasn't. Hence this.

api-server **1166 pass**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)