### PR TITLE
ci(release): retry the R2 mirror, and let a failed publish job be re-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1519,12 +1519,33 @@ jobs:
             prerelease_flag+=(--prerelease)
           fi
 
-          gh release create "${RELEASE_TAG}" \
-            --repo "${RELEASE_GH_REPO}" \
-            --title "${RELEASE_TITLE}" \
-            --notes-file "${notes_path}" \
-            "${prerelease_flag[@]}" \
-            "${upload_paths[@]}"
+          # Idempotent, so a re-run can finish a job that died AFTER this step.
+          #
+          # This step publishing and a later one failing (the R2 mirror hitting
+          # a 502, say) used to leave the job unrepeatable: re-running restarts
+          # from step 1, `gh release create` refuses because the release now
+          # exists, and the steps that actually still needed to run never get
+          # reached. The visible symptom is a re-run failing with a DIFFERENT
+          # error than the original — "release already exists" — which says
+          # nothing about what went wrong.
+          #
+          # A fresh dispatch with a taken tag is still rejected early by
+          # `ensure-release`, so clobbering here only ever applies to a re-run
+          # of the run that created the release.
+          if gh release view "${RELEASE_TAG}" --repo "${RELEASE_GH_REPO}" >/dev/null 2>&1; then
+            echo "release ${RELEASE_TAG} already exists — re-uploading assets and continuing"
+            gh release upload "${RELEASE_TAG}" \
+              --repo "${RELEASE_GH_REPO}" \
+              --clobber \
+              "${upload_paths[@]}"
+          else
+            gh release create "${RELEASE_TAG}" \
+              --repo "${RELEASE_GH_REPO}" \
+              --title "${RELEASE_TITLE}" \
+              --notes-file "${notes_path}" \
+              "${prerelease_flag[@]}" \
+              "${upload_paths[@]}"
+          fi
 
       # Mirror every binary the previous step pushed to holaOS-releases
       # up to a Cloudflare R2 bucket. GitHub Releases stay authoritative
@@ -1634,10 +1655,31 @@ jobs:
                 cache_control="public, max-age=31536000, immutable"
               fi
               echo "  → ${dest_key} (${cache_control})"
-              aws s3 cp "${asset}" "s3://${R2_BUCKET}/${dest_key}" \
-                --endpoint-url "${R2_ENDPOINT_URL}" \
-                --cache-control "${cache_control}" \
-                --only-show-errors
+              # Retried around the CLI's own retries. These are ~450MB
+              # multipart uploads and R2 returns a transient 502 on
+              # UploadPart often enough to have taken out a release: the CLI
+              # gave up after its default attempts, the step aborted on its
+              # FIRST file, and no asset reached the bucket — leaving the
+              # channel pointer serving the previous version while GitHub
+              # advertised the new one.
+              #
+              # AWS_MAX_ATTEMPTS raises the per-request budget; the loop
+              # covers a whole transfer dying midway, which no per-request
+              # setting can.
+              upload_attempt=1
+              until AWS_MAX_ATTEMPTS=10 AWS_RETRY_MODE=adaptive \
+                aws s3 cp "${asset}" "s3://${R2_BUCKET}/${dest_key}" \
+                  --endpoint-url "${R2_ENDPOINT_URL}" \
+                  --cache-control "${cache_control}" \
+                  --only-show-errors; do
+                if [ "${upload_attempt}" -ge 3 ]; then
+                  echo "::error::failed to mirror ${name} to ${dest_key} after ${upload_attempt} attempts"
+                  exit 1
+                fi
+                echo "  retrying ${dest_key} (attempt $((upload_attempt + 1)))"
+                upload_attempt=$((upload_attempt + 1))
+                sleep $((upload_attempt * 10))
+              done
             done
           done
 

--- a/apps/desktop/electron/release-channel-policy.test.mjs
+++ b/apps/desktop/electron/release-channel-policy.test.mjs
@@ -134,7 +134,26 @@ test("manual CI workflow publishes desktop installers without standalone runtime
   assert.doesNotMatch(source, /RUNTIME_ASSET_NAME: holaOS-runtime-linux\.tar\.gz/);
   assert.doesNotMatch(source, /RUNTIME_ASSET_NAME: holaboss-runtime-macos\.tar\.gz/);
   assert.doesNotMatch(source, /RUNTIME_ASSET_NAME: holaboss-runtime-windows\.tar\.gz/);
-  assert.doesNotMatch(source, /gh release upload "\$\{RELEASE_TAG\}"/);
+  // `gh release upload` existed only to attach standalone runtime tarballs, so
+  // banning the command stood in for banning that behaviour. Publishing is
+  // idempotent now — a re-run re-attaches the SAME curated installer list
+  // instead of failing on an already-created release — so the command itself is
+  // legitimate and the invariant has to be stated directly: whatever it
+  // uploads is `upload_paths`, never a tarball. The RUNTIME_ASSET_NAME and
+  // HOLABOSS_RUNTIME_TARBALL assertions above still cover the rest, and this
+  // keeps the test honest to its own name rather than to one command.
+  for (const [invocation] of source.matchAll(/gh release upload[\s\S]{0,240}/g)) {
+    assert.match(
+      invocation,
+      /"\$\{upload_paths\[@\]\}"/,
+      "a release upload must publish the curated installer list, nothing else",
+    );
+    assert.doesNotMatch(
+      invocation,
+      /\.tar\.gz/,
+      "standalone runtime tarballs must not be attached to a desktop release",
+    );
+  }
   assert.match(source, /Build desktop code for macOS release/);
   assert.match(source, /- name: Install workspace dependencies \(covers desktop\)\n\s+env:\n\s+ELECTRON_SKIP_BINARY_DOWNLOAD: "1"\n\s+run: bun install --frozen-lockfile/);
   assert.match(source, /Build signed macOS app bundle/);


### PR DESCRIPTION
`holaOS-2026.819.3` published to GitHub and then failed:

```
Mirroring 3 install package(s) to R2
upload failed: holaOS-windows-x64-setup.exe → s3://…/desktop/latest/
  An error occurred (502) when calling the UploadPart operation
  (reached max retries: 2): Bad Gateway
```

Two independent defects, and together they left the CDN serving the wrong build.

## 1. The upload had no retry budget

These are ~450MB multipart uploads and R2 returns transient 502s on `UploadPart`. The CLI gave up after its default attempts and the step aborted on its **first** file, so **no** asset reached the bucket.

The channel pointer (`desktop/latest/`) keeps its URL across releases, so the previous version's binaries stayed put and kept returning 200:

| | GitHub `.3` | CDN was serving |
|---|---|---|
| windows-x64-setup.exe | 457,614,976 | 457,625,352 (13:18 — that's `.2`) |
| macos-arm64.dmg | 479,376,509 | 479,357,651 (13:20 — that's `.2`) |

GitHub advertised 2026.819.3; `assets.holaboss.ai` served 2026.819.2. Nothing failed loudly enough to say so.

Now retried at two levels: `AWS_MAX_ATTEMPTS` raises the per-request budget, and a loop around the whole `aws s3 cp` covers a transfer dying midway — which no per-request setting can.

## 2. The job couldn't be re-run

Re-running restarts from step 1, and `gh release create` refuses once the release exists. So the re-run failed with **"release already exists"** — an error that says nothing about the real problem — and the steps that still needed to run were never reached.

Publishing is now idempotent: an existing release gets its assets re-uploaded with `--clobber` and the job continues to the mirror and cache purge. A fresh dispatch with a taken tag is still rejected up front by `ensure-release`, so clobbering only applies to a re-run of the run that created the release.

## Not fixed here

**`2026.819.3`'s assets are still missing from R2.** This change makes the mirror re-runnable but doesn't perform it — see the note below on how to land it.

Both edited shell blocks parse (`bash -n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)