### PR TITLE
fix(runtime): follow session-cookie rotation instead of holding the spawn-time one

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8429,6 +8429,26 @@ function setupDevRuntimeHotReload(): void {
   }
 }
 
+/**
+ * Forward a rotated session cookie to the running runtime.
+ *
+ * Best-effort and deliberately silent: the runtime may not be up yet (this can
+ * fire during startup, before the first spawn), and a failure here must never
+ * break the caller — authCookieHeader() is on the path of ordinary requests.
+ * A missed push self-corrects on the next rotation, and the spawn environment
+ * carries the current value for any runtime started afterwards.
+ */
+function pushAuthCookieToRuntime(cookie: string): Promise<void> {
+  return fetch(`${runtimeBaseUrl()}/api/v1/capabilities/auth-session`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ cookie }),
+    signal: AbortSignal.timeout(5_000),
+  })
+    .then(() => undefined)
+    .catch(() => undefined);
+}
+
 function authCookieHeader() {
   if (!desktopAuthClient) {
     return "";
@@ -8466,6 +8486,13 @@ function authCookieHeader() {
     if (live !== cachedCookieHeader) {
       cachedCookieHeader = live;
       persistPlaintextAuthCache(live);
+      // The runtime holds its own copy, taken from HOLABOSS_AUTH_COOKIE at
+      // spawn. This function exists because that value rotates; the runtime had
+      // no way to hear about it, so its cookie-authenticated calls (Composio
+      // search / connections / proxy) eventually 401 while chat keeps working
+      // on the model-proxy key. Rotation is detected exactly here, so this is
+      // where it gets forwarded.
+      void pushAuthCookieToRuntime(live);
     }
     return live;
   }

--- a/runtime/api-server/src/app.ts
+++ b/runtime/api-server/src/app.ts
@@ -6190,6 +6190,37 @@ export function buildRuntimeApiServer(options: BuildRuntimeApiServerOptions = {}
     }
   });
 
+  // The desktop pushes a rotated session cookie here.
+  //
+  // HOLABOSS_AUTH_COOKIE is read once, from the spawn environment, so the
+  // runtime held whatever the session was when it started. Better-auth rotates
+  // that cookie silently (the backend reissues it on get-session and most
+  // auth-touching endpoints), and the desktop follows the rotation — its
+  // authCookieHeader() stopped caching for precisely this reason. The runtime
+  // did not, so every cookie-authenticated call eventually 401s: Composio
+  // search, connections and proxy all fail while chat keeps working, because
+  // chat authenticates with the model-proxy key instead.
+  //
+  // Nothing here is a new secret: it is the same session the desktop already
+  // holds, transported to the process that needs it.
+  app.post("/api/v1/capabilities/auth-session", async (request, reply) => {
+    if (!isRecord(request.body)) {
+      return sendError(reply, 400, "body must be an object");
+    }
+    const cookie =
+      typeof request.body.cookie === "string" ? request.body.cookie : "";
+    if (!cookie.trim()) {
+      return sendError(reply, 400, "cookie is required");
+    }
+    if (!composioService) {
+      // Not an error: the runtime can outlive a session it never had a service
+      // for, and the desktop should not have to know which services exist.
+      return { updated: false, reason: "composio service not configured" };
+    }
+    composioService.setAuthCookie(cookie);
+    return { updated: true };
+  });
+
   app.post("/api/v1/capabilities/composio-search", async (request, reply) => {
     try {
       if (!composioService) {

--- a/runtime/api-server/src/auth-cookie-rotation.test.ts
+++ b/runtime/api-server/src/auth-cookie-rotation.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { ComposioService } from "./composio-service.js";
+
+/**
+ * The runtime's session cookie has to survive rotation.
+ *
+ * It arrives once, in HOLABOSS_AUTH_COOKIE, from the spawn environment.
+ * Better-auth reissues the cookie silently (the backend sends a fresh
+ * Set-Cookie on get-session and most auth-touching endpoints), and the desktop
+ * follows that — its authCookieHeader() deliberately stopped caching for this
+ * exact reason. The runtime did not, so its cookie-authenticated calls
+ * eventually 401 while chat keeps working on the model-proxy key. Observed
+ * live: a Composio search failing with 401 {"error":"unauthorized"}.
+ */
+
+function service(cookie: string) {
+  return new ComposioService({
+    honoBaseUrl: "https://example.test",
+    authCookie: cookie,
+    fetchImpl: (async () => new Response("{}")) as unknown as typeof fetch,
+  });
+}
+
+test("a rotated cookie replaces the one taken at startup", () => {
+  const composio = service("better-auth.session=old");
+  composio.setAuthCookie("better-auth.session=new");
+  assert.equal(composio.authCookie, "better-auth.session=new");
+});
+
+test("the cookie is read through a getter, not captured per call site", () => {
+  // Three call sites send Cookie: proxy, listConnections and searchTools. If
+  // any captured the constructor value, a rotation would fix some and not
+  // others — the confusing half-broken state.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const text = readFileSync(path.join(here, "composio-service.ts"), "utf-8");
+  assert.match(text, /get authCookie\(\): string/);
+  assert.doesNotMatch(
+    text,
+    /readonly authCookie/,
+    "a readonly field cannot be rotated",
+  );
+});
+
+test("an empty push is ignored rather than signing the runtime out", () => {
+  // "" means "the desktop does not know yet" — during startup, or when
+  // better-auth storage is briefly unreadable. Adopting it would turn a
+  // transient gap into a hard 401 on every subsequent call.
+  const composio = service("better-auth.session=live");
+  composio.setAuthCookie("");
+  composio.setAuthCookie("   ");
+  assert.equal(composio.authCookie, "better-auth.session=live");
+});
+
+test("the leading '; ' from better-auth is stripped on both paths", () => {
+  // Passed verbatim, Hono on Workers sees an empty leading cookie pair and the
+  // session middleware crashes — a generic 500 instead of a clean 401. The
+  // constructor already handled this; the rotation path has to as well, or a
+  // refresh reintroduces the bug the constructor was fixing.
+  const composio = service("; better-auth.session=one");
+  assert.equal(composio.authCookie, "better-auth.session=one");
+  composio.setAuthCookie("; better-auth.session=two");
+  assert.equal(composio.authCookie, "better-auth.session=two");
+});

--- a/runtime/api-server/src/composio-service.ts
+++ b/runtime/api-server/src/composio-service.ts
@@ -80,10 +80,50 @@ export interface ComposioConnectionSummary {
   createdAt: string;
 }
 
+/**
+ * Better Auth's Electron client returns the cookie header as `; name=value`
+ * (leading "; " — meant for splicing onto an existing Cookie header). Passed
+ * verbatim as a fresh `Cookie:` header, Hono on Cloudflare Workers sees a
+ * leading empty cookie pair and the session-auth middleware crashes → the
+ * Worker bubbles a generic 500 instead of a clean 401. Strip leading whitespace
+ * and semicolons so the header starts with a real `name=value` pair.
+ */
+function normalizeAuthCookie(raw: string): string {
+  return (raw ?? "").replace(/^[\s;]+/, "").trim();
+}
+
 export class ComposioService {
   readonly honoBaseUrl: string;
-  readonly authCookie: string;
+  private currentAuthCookie: string;
   private readonly fetchImpl: typeof fetch;
+
+  /**
+   * Read per request, never captured.
+   *
+   * The session cookie ROTATES: better-auth reissues it whenever the backend
+   * sends a fresh Set-Cookie, which happens silently on get-session and most
+   * auth-touching endpoints. The desktop already accounts for that — its
+   * authCookieHeader() deliberately stopped caching for exactly this reason —
+   * but it hands the runtime a value once, in the spawn environment, so the
+   * runtime kept presenting a pre-rotation cookie for as long as it lived.
+   *
+   * Every call went through `this.authCookie`, captured in the constructor, so
+   * there was nowhere to put a newer one even if we had it. Reading through a
+   * getter is what makes `setAuthCookie` possible at all.
+   */
+  get authCookie(): string {
+    return this.currentAuthCookie;
+  }
+
+  /** Adopt a rotated session cookie. Ignores empty values: an empty cookie is
+   *  "we don't know yet", not "sign the runtime out". */
+  setAuthCookie(next: string): void {
+    const normalized = normalizeAuthCookie(next);
+    if (!normalized || normalized === this.currentAuthCookie) {
+      return;
+    }
+    this.currentAuthCookie = normalized;
+  }
 
   constructor(config: ComposioServiceConfig) {
     this.honoBaseUrl = config.honoBaseUrl.replace(/\/+$/, "");
@@ -94,7 +134,7 @@ export class ComposioService {
     // → the Worker bubbles a generic 500 "Internal Server Error" instead of a
     // clean 401. Strip the leading `; ` (and any other leading whitespace /
     // semicolons) so the header starts with the first real `name=value` pair.
-    this.authCookie = config.authCookie.replace(/^[\s;]+/, "");
+    this.currentAuthCookie = normalizeAuthCookie(config.authCookie);
     this.fetchImpl = config.fetchImpl ?? fetch;
   }
 

--- a/runtime/harnesses/src/composio-inline-tools.ts
+++ b/runtime/harnesses/src/composio-inline-tools.ts
@@ -259,12 +259,28 @@ function buildComposioMetaTools(ctx: {
           typeof payload.detail === "string" && payload.detail.trim()
             ? payload.detail.trim()
             : `composio-search failed (status ${response.status})`;
+        // A 401 here is the RUNTIME's session, not the integration's.
+        //
+        // The cookie only identifies whose connections to scope results to; the
+        // Composio credential lives server-side, past the gateway. But the
+        // failure surfaced as a bare `401 {"error":"unauthorized"}` next to a
+        // toolkit slug, and a model reading that concluded "the composio search
+        // tools are unauthorized" — then went looking for a workaround for a
+        // problem that had nothing to do with the toolkit. Observed live on a
+        // Notion search.
+        //
+        // Saying which credential expired costs one line and stops the next
+        // reader — human or model — drawing the same wrong conclusion.
+        const sessionExpired = /\b401\b|unauthorized/i.test(detail);
+        const cause = sessionExpired
+          ? "\nThis is the runtime's own sign-in session, NOT the integration's authorization: the toolkit's connection is unaffected. Restarting the app re-establishes it. Do not suggest reconnecting the integration."
+          : "";
         const scope = toolkitSlug ? `:${toolkitSlug}` : "";
         return {
           content: [
             {
               type: "text" as const,
-              text: `[composio_error:search_failed${scope}] ${detail}\nThe search did NOT run — this is not "no matching tools". Retry, or list the toolkit's catalogue with only toolkit_slug.`,
+              text: `[composio_error:search_failed${scope}] ${detail}${cause}\nThe search did NOT run — this is not "no matching tools". Retry, or list the toolkit's catalogue with only toolkit_slug.`,
             },
           ],
           details: { tool_id: "composio_search_tools", ok: false },


### PR DESCRIPTION
Composio search failed with `401 {"error":"unauthorized"}` while chat kept working.

The 401 was neither Composio's nor the Notion connection's — it was the **Hono gateway rejecting the runtime's session cookie**.

## Cause

The runtime reads that cookie **once**, from `HOLABOSS_AUTH_COOKIE` in its spawn environment:

```ts
const authCookie = process.env.HOLABOSS_AUTH_COOKIE ?? "";   // app.ts
HOLABOSS_AUTH_COOKIE: authCookieHeader() ?? "",              // electron/main.ts
```

Better-auth rotates that cookie silently — the backend reissues it on `get-session` and most auth-touching endpoints. The desktop already accounts for this; `authCookieHeader()` deliberately stopped caching, and its comment describes the same bug one layer up:

> *"When we cached the very first cookie value forever, every subsequent `authCookieHeader()` returned the pre-rotation token."*

It then hands the runtime a snapshot, so the runtime kept presenting a pre-rotation cookie for its whole life.

Only cookie-authenticated paths break (Composio search / connections / proxy), which is why it reads as "Composio is broken" rather than "signed out" — chat authenticates with the model-proxy key instead.

## Fix, in three parts

**`ComposioService` reads through a getter** rather than a `readonly` field captured in the constructor, so a newer cookie has somewhere to go. Empty pushes are ignored — `""` means "the desktop doesn't know yet", and adopting it would turn a transient gap into a hard 401 on every later call. The leading `"; "` better-auth emits is stripped on the rotation path too; without that, a refresh would reintroduce the 500-instead-of-401 the constructor already guarded against.

**A `capabilities/auth-session` route** accepts the rotated cookie, and the desktop pushes **at the point it already detects rotation**. Best-effort and silent: the runtime may not be up, and this sits on the path of ordinary requests. A missed push self-corrects on the next rotation.

**The 401 now names the credential that expired.** A bare `401 unauthorized` beside a toolkit slug is what led a model to conclude *"the composio search tools are unauthorized"* and go hunting for a workaround to a problem the toolkit never had. The cookie only scopes results to your connections; the Composio credential lives past the gateway.

## Testing

api-server **1170 pass**, harnesses **62 pass**, desktop typecheck clean. Guards cover rotation, the empty-push rejection, the `"; "` stripping on both paths, and that no call site captures the cookie (three send it — a captured one would leave a half-refreshed state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)