### PR TITLE
feat: add OrcaRouter as a named provider kind and desktop BYOK preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Context, preferences, and project history live in a single shared memory — sto
 
 ### 💸 Models your way — built in, or bring your own
 
-One account, every model — no keys, no setup, no switching between providers. The latest frontier models are **built in**: cost-efficient **Kimi K3** and **GLM 5.2** for everyday volume, plus top-tier **GPT 5.6**, **Claude Opus 5**, and **Fable 5** for the hard problems. Prefer your own provider? **Bring your own keys** for OpenAI, Anthropic, or any OpenAI- or Anthropic-compatible endpoint — those run on _your_ account, not your holaOS plan.
+One account, every model — no keys, no setup, no switching between providers. The latest frontier models are **built in**: cost-efficient **Kimi K3** and **GLM 5.2** for everyday volume, plus top-tier **GPT 5.6**, **Claude Opus 5**, and **Fable 5** for the hard problems. Prefer your own provider? **Bring your own keys** for OpenAI, Anthropic, [OrcaRouter](https://www.orcarouter.ai), or any OpenAI- or Anthropic-compatible endpoint — those run on _your_ account, not your holaOS plan.
 
 - **Zero-setup default** — one account, every SOTA model, no API keys to manage.
 - **BYOK when you want it** — your keys, your providers, your rates.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -431,6 +431,7 @@ const RUNTIME_PROVIDER_KIND_HOLABOSS_PROXY = "holaboss_proxy";
 const RUNTIME_PROVIDER_KIND_OPENAI_COMPATIBLE = "openai_compatible";
 const RUNTIME_PROVIDER_KIND_ANTHROPIC_NATIVE = "anthropic_native";
 const RUNTIME_PROVIDER_KIND_OPENROUTER = "openrouter";
+const RUNTIME_PROVIDER_KIND_ORCAROUTER = "orcarouter";
 const RUNTIME_HOLABOSS_PROVIDER_ID = "holaboss_model_proxy";
 const RUNTIME_HOLABOSS_PROVIDER_ALIASES = [
   "holaboss",
@@ -5590,6 +5591,7 @@ const PROVIDER_DEFAULT_BASE_URL: Record<string, string> = {
   gemini_direct: "https://generativelanguage.googleapis.com/v1beta/openai",
   minimax: "https://api.minimaxi.chat",
   ollama_local: "http://localhost:11434",
+  orcarouter: "https://api.orcarouter.ai/v1",
 };
 
 function trimTrailingSlash(value: string): string {
@@ -6596,6 +6598,9 @@ function runtimeProviderLabel(providerId: string): string {
   if (normalized.includes("openrouter")) {
     return "OpenRouter";
   }
+  if (normalized.includes("orcarouter")) {
+    return "OrcaRouter";
+  }
   if (normalized.includes("gemini") || normalized.includes("google")) {
     return "Gemini";
   }
@@ -6645,6 +6650,12 @@ function normalizeRuntimeProviderKind(
     return RUNTIME_PROVIDER_KIND_OPENROUTER;
   }
   if (
+    normalizedKind === RUNTIME_PROVIDER_KIND_ORCAROUTER ||
+    normalizedProviderId.includes("orcarouter")
+  ) {
+    return RUNTIME_PROVIDER_KIND_ORCAROUTER;
+  }
+  if (
     normalizedKind === RUNTIME_PROVIDER_KIND_ANTHROPIC_NATIVE ||
     normalizedKind === "anthropic" ||
     normalizedProviderId.includes("anthropic")
@@ -6669,6 +6680,7 @@ function runtimeModelIdFromToken(token: string): string {
     normalizedPrefix.includes("anthropic") ||
     normalizedPrefix.includes("holaboss") ||
     normalizedPrefix.includes("openrouter") ||
+    normalizedPrefix.includes("orcarouter") ||
     normalizedPrefix.includes("gemini") ||
     normalizedPrefix.includes("google") ||
     normalizedPrefix.includes("ollama") ||

--- a/apps/desktop/src/lib/providerFormPresets.test.ts
+++ b/apps/desktop/src/lib/providerFormPresets.test.ts
@@ -17,6 +17,17 @@ test("Atlas Cloud preset uses the OpenAI-compatible endpoint", () => {
   });
 });
 
+test("OrcaRouter preset uses the OrcaRouter OpenAI-compatible gateway endpoint", () => {
+  assert.deepEqual(providerFormPreset("orcarouter"), {
+    id: "orcarouter",
+    label: "OrcaRouter",
+    displayName: "OrcaRouter",
+    providerType: "openai_compatible",
+    apiHost: "https://api.orcarouter.ai/v1",
+    keyPlaceholder: "sk-orca-…",
+  });
+});
+
 test("unknown provider presets fall back to an empty custom form", () => {
   const preset = providerFormPreset("unknown");
 

--- a/apps/desktop/src/lib/providerFormPresets.ts
+++ b/apps/desktop/src/lib/providerFormPresets.ts
@@ -26,6 +26,14 @@ export const PROVIDER_FORM_PRESETS = [
     apiHost: "https://api.atlascloud.ai/v1",
     keyPlaceholder: "sk-…",
   },
+  {
+    id: "orcarouter",
+    label: "OrcaRouter",
+    displayName: "OrcaRouter",
+    providerType: "openai_compatible",
+    apiHost: "https://api.orcarouter.ai/v1",
+    keyPlaceholder: "sk-orca-…",
+  },
 ] as const satisfies readonly ProviderFormPreset[];
 
 export function providerFormPreset(presetId: string): ProviderFormPreset {

--- a/apps/docs/content/docs/contribute/desktop/model-configuration.mdx
+++ b/apps/docs/content/docs/contribute/desktop/model-configuration.mdx
@@ -25,6 +25,7 @@ The OSS runtime supports the following provider kinds:
 | `google_compatible` | Gemini via the Google OpenAI-compat path | Uses the Google compatibility surface instead of the generic OpenAI-compatible routing path. |
 | `anthropic_native` | Anthropic accounts and native workflows | Good when you want the provider's own integration path. |
 | `openrouter` | Model experimentation and broad access | Useful when you want to swap models without changing the rest of the setup. |
+| `orcarouter` | Unified gateway with smart routing | Use one API key for many upstream models behind the [OrcaRouter](https://www.orcarouter.ai) gateway; same OpenAI-compatible surface as `openai_compatible`. |
 
 Desktop currently exposes only holaOS Proxy in `Settings -> Model Providers`. The broader provider kinds below still describe lower-level runtime capabilities and legacy config shapes, but they are no longer first-class desktop provider choices.
 

--- a/runtime/api-server/src/agent-runtime-config.test.ts
+++ b/runtime/api-server/src/agent-runtime-config.test.ts
@@ -2092,3 +2092,76 @@ test("projectAgentRuntimeConfig keeps direct OpenRouter providers on the provide
     "X-OpenRouter-Categories": "personal-agent,general-chat",
   });
 });
+
+test("projectAgentRuntimeConfig keeps direct OrcaRouter providers on the provider endpoint", () => {
+  const root = makeTempDir("hb-agent-runtime-config-");
+  process.env.HB_SANDBOX_ROOT = root;
+  process.env.HOLABOSS_RUNTIME_CONFIG_PATH = writeRuntimeConfigDocument(root, {
+    runtime: {
+      sandbox_id: "sandbox-from-runtime",
+      default_provider: "orcarouter",
+    },
+    providers: {
+      holaboss_model_proxy: {
+        kind: "holaboss_proxy",
+        base_url: "https://proxy.example/api/v1/model-proxy",
+        api_key: "hb-token",
+      },
+      orcarouter: {
+        kind: "orcarouter",
+        base_url: "https://api.orcarouter.ai/v1",
+        api_key: "orca-key",
+      },
+    },
+    integrations: {
+      holaboss: {
+        enabled: true,
+        auth_token: "hb-token",
+        sandbox_id: "sandbox-from-binding",
+        user_id: "user-1",
+      },
+    },
+    models: {
+      "orcarouter/auto": {
+        provider_id: "orcarouter",
+        model_id: "orcarouter/auto",
+      },
+    },
+  });
+
+  const result = projectAgentRuntimeConfig({
+    session_id: "session-1",
+    workspace_id: "workspace-1",
+    input_id: "input-1",
+    session_kind: "main_session",
+    harness_id: "pi",
+    browser_tools_available: false,
+    browser_tool_ids: [],
+    runtime_tool_ids: [],
+    workspace_command_ids: [],
+    runtime_exec_model_proxy_api_key: "hb-runtime-token",
+    runtime_exec_sandbox_id: "sandbox-from-exec-context",
+    runtime_exec_run_id: "run-1",
+    selected_model: "orcarouter/auto",
+    default_provider_id: "holaboss_model_proxy",
+    session_mode: "code",
+    workspace_config_checksum: "checksum-1",
+    workspace_skill_ids: [],
+    default_tools: ["read"],
+    extra_tools: [],
+    resolved_mcp_tool_refs: [],
+    resolved_output_schemas: {},
+    agent: {
+      id: "workspace.general",
+      model: "gpt-5.2",
+      prompt: "You are concise.",
+    },
+  });
+
+  assert.equal(result.provider_id, "orcarouter");
+  assert.equal(result.model_client.api_key, "orca-key");
+  assert.equal(result.model_client.base_url, "https://api.orcarouter.ai/v1");
+  assert.equal(result.model_id, "orcarouter/auto");
+  assert.equal(result.model_client.model_proxy_provider, "openai_compatible");
+  assert.equal(result.model_client.default_headers, null);
+});

--- a/runtime/api-server/src/agent-runtime-config.ts
+++ b/runtime/api-server/src/agent-runtime-config.ts
@@ -181,6 +181,7 @@ const PROVIDER_KIND_HOLABOSS_PROXY = "holaboss_proxy";
 const PROVIDER_KIND_OPENAI_COMPATIBLE = "openai_compatible";
 const PROVIDER_KIND_ANTHROPIC_NATIVE = "anthropic_native";
 const PROVIDER_KIND_OPENROUTER = "openrouter";
+const PROVIDER_KIND_ORCAROUTER = "orcarouter";
 const HOLABOSS_PROXY_PROVIDER_ID = "holaboss_model_proxy";
 const DEFAULT_RUNTIME_STRUCTURED_RETRY_COUNT = 2;
 const DIRECT_OPENAI_FALLBACK_FLAG =
@@ -191,8 +192,11 @@ const DIRECT_ANTHROPIC_API_KEY_ENV = "ANTHROPIC_API_KEY";
 const DIRECT_ANTHROPIC_BASE_URL_ENV = "ANTHROPIC_BASE_URL";
 const DIRECT_OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY";
 const DIRECT_OPENROUTER_BASE_URL_ENV = "OPENROUTER_BASE_URL";
+const DIRECT_ORCAROUTER_API_KEY_ENV = "ORCAROUTER_API_KEY";
+const DIRECT_ORCAROUTER_BASE_URL_ENV = "ORCAROUTER_BASE_URL";
 const DEFAULT_DIRECT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_DIRECT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_DIRECT_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1";
 const OPENROUTER_ATTRIBUTION_REFERER = "https://holaboss.ai";
 const OPENROUTER_ATTRIBUTION_TITLE = "holaOS";
 const OPENROUTER_ATTRIBUTION_CATEGORIES = "personal-agent,general-chat";
@@ -415,6 +419,12 @@ function normalizeProviderKind(
     normalizedProviderId.includes("openrouter")
   ) {
     return PROVIDER_KIND_OPENROUTER;
+  }
+  if (
+    normalizedKind === PROVIDER_KIND_ORCAROUTER ||
+    normalizedProviderId.includes("orcarouter")
+  ) {
+    return PROVIDER_KIND_ORCAROUTER;
   }
   if (
     normalizedKind === PROVIDER_KIND_ANTHROPIC_NATIVE ||
@@ -1225,6 +1235,19 @@ function configuredProviderFallbackCredentials(
       ).replace(/\/+$/, ""),
     };
   }
+  if (provider.kind === PROVIDER_KIND_ORCAROUTER) {
+    return {
+      apiKey: firstNonEmptyString(
+        provider.apiKey,
+        process.env[DIRECT_ORCAROUTER_API_KEY_ENV],
+      ),
+      baseRoot: firstNonEmptyString(
+        provider.baseUrl,
+        process.env[DIRECT_ORCAROUTER_BASE_URL_ENV],
+        DEFAULT_DIRECT_ORCAROUTER_BASE_URL,
+      ).replace(/\/+$/, ""),
+    };
+  }
   if (
     provider.kind === PROVIDER_KIND_ANTHROPIC_NATIVE ||
     normalizedModelProxyProvider === MODEL_PROXY_PROVIDER_ANTHROPIC_NATIVE
@@ -1278,6 +1301,9 @@ function configuredDirectProviderBaseUrl(
 ): string {
   const normalizedProvider = normalizeModelProxyProvider(modelProxyProvider);
   if (provider.kind === PROVIDER_KIND_OPENROUTER) {
+    return normalizeDirectProviderBaseUrl(baseRoot, normalizedProvider);
+  }
+  if (provider.kind === PROVIDER_KIND_ORCAROUTER) {
     return normalizeDirectProviderBaseUrl(baseRoot, normalizedProvider);
   }
   return baseUrlForProvider(baseRoot, normalizedProvider);
@@ -1469,7 +1495,9 @@ function resolveModelClientConfig(
             )
           : configuredProvider.kind === PROVIDER_KIND_OPENROUTER
             ? normalizeDirectProviderBaseUrl(credentials.baseRoot)
-            : baseUrlForProvider(credentials.baseRoot, normalizedProvider);
+            : configuredProvider.kind === PROVIDER_KIND_ORCAROUTER
+              ? normalizeDirectProviderBaseUrl(credentials.baseRoot)
+              : baseUrlForProvider(credentials.baseRoot, normalizedProvider);
       const configuredHeaders =
         Object.keys(configuredProvider.headers).length > 0
           ? { ...configuredProvider.headers }


### PR DESCRIPTION
## Summary

This PR adds **OrcaRouter** as a first-class, named model provider for holaOS — both in the runtime provider resolution and in the desktop BYOK (bring-your-own-key) settings form.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model gateway: one API key routes to many upstream models through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **Runtime provider kind** (`runtime/api-server/src/agent-runtime-config.ts`): add `PROVIDER_KIND_ORCAROUTER`, mirroring the existing `openrouter` direct-provider wiring. OrcaRouter providers resolve against `https://api.orcarouter.ai/v1` (configurable via `ORCAROUTER_BASE_URL`) with `ORCAROUTER_API_KEY` as the credential, and route through the OpenAI-compatible chat path.
- **Desktop BYOK preset** (`apps/desktop/src/lib/providerFormPresets.ts`): add an `OrcaRouter` preset to the create-provider form, pre-filling the gateway base URL and `sk-orca-…` key placeholder.
- **Desktop provider label / model id display** (`apps/desktop/electron/main.ts`): label OrcaRouter providers in the model picker and strip the `orcarouter/` prefix from model ids for display.
- **Docs**: document the `orcarouter` provider kind in `apps/docs/content/docs/contribute/desktop/model-configuration.mdx` and mention OrcaRouter in the README BYOK section.

## Validation

- `agent-runtime-config.test.ts`: 29/29 pass (includes new OrcaRouter direct-provider resolution test).
- `providerFormPresets.test.ts`: 3/3 pass (new OrcaRouter preset test).
- `pi.test.ts`: 100/100 pass.
- `model-routing.test.ts`: 3/3 pass.
- Desktop `tsc --noEmit`: no new errors (baseline has 122 pre-existing errors from unbuilt workspace deps; OrcaRouter changes add zero).
- **L3 live check**: ran the real `projectAgentRuntimeConfig` resolution with an OrcaRouter provider and hit `https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/auto` → **HTTP 200** `ORCA-LIVE-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.