### PR TITLE
fix(desktop): make the post-connect hook refresh tools instead of calling a deleted route

### DIFF
--- a/apps/desktop/electron/composio-connect-refresh.test.mjs
+++ b/apps/desktop/electron/composio-connect-refresh.test.mjs
@@ -5,6 +5,29 @@ import test from "node:test";
 const MAIN_PATH = new URL("./main.ts", import.meta.url);
 
 /**
+ * The body of a top-level function, from its signature to the next one.
+ *
+ * Matching with an unbounded `[\s\S]*?` across a 30k-line file is not a guard:
+ * it happily spans unrelated code, so a function repointed at a dead route still
+ * "passes" as long as the live path is mentioned ANYWHERE later in the file.
+ * That was demonstrated against the first version of this test.
+ */
+async function functionBody(name) {
+  const lines = (await readFile(MAIN_PATH, "utf8")).split("\n");
+  const signature = new RegExp(`^(?:export\\s+)?(?:async\\s+)?function ${name}\\b`);
+  const start = lines.findIndex((line) => signature.test(line));
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^(?:export\s+)?(?:async\s+)?function [\w$]+/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+/**
  * The post-connect hook has to target a capability the runtime actually serves.
  *
  * `/api/v1/composio-mcp/ensure-running` was removed when Composio tools moved
@@ -18,11 +41,13 @@ const MAIN_PATH = new URL("./main.ts", import.meta.url);
  * A dead endpoint fails silently by construction, so pin the live one.
  */
 test("the post-connect hook refreshes tools instead of calling the deleted composio-mcp host", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
 
-  assert.match(
-    source,
-    /async function composioMcpEnsureRunning\(workspaceId: string\): Promise<unknown> \{\s*return refreshWorkspaceMcpTools\(workspaceId\);\s*\}/,
+  const body = await functionBody("composioMcpEnsureRunning");
+  assert.ok(body, "composioMcpEnsureRunning not found — did the signature change?");
+  // Pin the DELEGATION, not the signature: tightening the return type is a
+  // behaviour-preserving improvement and must not fail this guard.
+  assert.ok(
+    body.includes("return refreshWorkspaceMcpTools(workspaceId);"),
     "composioMcpEnsureRunning must delegate to refreshWorkspaceMcpTools",
   );
 });
@@ -51,10 +76,11 @@ test("nothing in the main process posts to the deleted composio-mcp route", asyn
  * pointing at that capability, the hook goes quiet again.
  */
 test("refreshWorkspaceMcpTools targets the runtime-tools refresh capability", async () => {
-  const source = await readFile(MAIN_PATH, "utf8");
+  const body = await functionBody("refreshWorkspaceMcpTools");
 
-  assert.match(
-    source,
-    /async function refreshWorkspaceMcpTools\([\s\S]*?path: "\/api\/v1\/capabilities\/runtime-tools\/mcp\/refresh"/,
+  assert.ok(body, "refreshWorkspaceMcpTools not found — did the signature change?");
+  assert.ok(
+    body.includes('path: "/api/v1/capabilities/runtime-tools/mcp/refresh"'),
+    "the refresh helper no longer posts the live capability, so the post-connect hook is inert again",
   );
 });

--- a/apps/desktop/electron/composio-connect-refresh.test.mjs
+++ b/apps/desktop/electron/composio-connect-refresh.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const MAIN_PATH = new URL("./main.ts", import.meta.url);
+
+/**
+ * The post-connect hook has to target a capability the runtime actually serves.
+ *
+ * `/api/v1/composio-mcp/ensure-running` was removed when Composio tools moved
+ * inline (the runtime now deletes the legacy `holaboss_composio` registry
+ * entry), but the desktop kept POSTing to it. Every call 404'd into the callers'
+ * `catch {}`, so the only step that made a just-connected integration's tools
+ * reachable silently did nothing — the runtime went on serving its cached tool
+ * listing and the agent reported the publish tool as "still loading" turn after
+ * turn.
+ *
+ * A dead endpoint fails silently by construction, so pin the live one.
+ */
+test("the post-connect hook refreshes tools instead of calling the deleted composio-mcp host", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+
+  assert.match(
+    source,
+    /async function composioMcpEnsureRunning\(workspaceId: string\): Promise<unknown> \{\s*return refreshWorkspaceMcpTools\(workspaceId\);\s*\}/,
+    "composioMcpEnsureRunning must delegate to refreshWorkspaceMcpTools",
+  );
+});
+
+test("nothing in the main process posts to the deleted composio-mcp route", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+  const offending = source
+    .split("\n")
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(
+      ({ line }) =>
+        line.includes("composio-mcp/ensure-running") && !line.trimStart().startsWith("*"),
+    )
+    .map(({ number }) => `main.ts:${number}`);
+
+  assert.deepEqual(
+    offending,
+    [],
+    `these call a route the api-server does not register, so they 404 silently:\n${offending.join("\n")}`,
+  );
+});
+
+/**
+ * The refresh helper is what makes the hook above worth calling: it drops the
+ * workspace's MCP tool cache AND the cached Composio listing. If it ever stops
+ * pointing at that capability, the hook goes quiet again.
+ */
+test("refreshWorkspaceMcpTools targets the runtime-tools refresh capability", async () => {
+  const source = await readFile(MAIN_PATH, "utf8");
+
+  assert.match(
+    source,
+    /async function refreshWorkspaceMcpTools\([\s\S]*?path: "\/api\/v1\/capabilities\/runtime-tools\/mcp\/refresh"/,
+  );
+});

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11873,12 +11873,28 @@ async function composioDeleteUpstream(
   }
 }
 
+/**
+ * Post-connect / post-install hook: make newly available tools reachable.
+ *
+ * The composio-mcp host this used to start no longer exists. Composio tools are
+ * resolved inline now, and the runtime actively removes the legacy
+ * `holaboss_composio` registry entry — so `/api/v1/composio-mcp/ensure-running`
+ * has had no route for some time and every call here 404'd straight into the
+ * callers' `catch {}`.
+ *
+ * That silently removed the only step that made a just-connected integration's
+ * tools reachable: the runtime kept serving its cached tool listing (15 min TTL),
+ * so the agent reported the publish tool as "still loading" turn after turn and
+ * users abandoned the task.
+ *
+ * Refreshing is the live equivalent — it drops the workspace's MCP tool cache and
+ * the cached Composio listing, so the next turn re-resolves both. Kept under the
+ * original name so the three renderer call sites (chat connect proposal, add-app,
+ * marketplace install) keep working; the name is stale and worth retiring
+ * separately.
+ */
 async function composioMcpEnsureRunning(workspaceId: string): Promise<unknown> {
-  return requestRuntimeJson<unknown>({
-    method: "POST",
-    path: "/api/v1/composio-mcp/ensure-running",
-    payload: { workspace_id: workspaceId },
-  });
+  return refreshWorkspaceMcpTools(workspaceId);
 }
 
 /**


### PR DESCRIPTION
## The bug

Connecting an integration from chat runs exactly one step to make its tools reachable — `composioMcpEnsureRunning` — and that step has been **dead**:

```ts
async function composioMcpEnsureRunning(workspaceId: string): Promise<unknown> {
  return requestRuntimeJson<unknown>({
    method: "POST",
    path: "/api/v1/composio-mcp/ensure-running",   // ← no such route
    payload: { workspace_id: workspaceId },
  });
}
```

The api-server registers no such route — Composio tools moved inline, and the runtime now *deletes* the legacy `holaboss_composio` registry entry. So every call 404'd straight into the callers' `catch {}`.

With that step silently doing nothing, the runtime kept serving its **cached Composio tool listing for the full 15 min TTL**. Production transcripts show the consequence:

> *"publishing now"* → *"send me one more message"* → *"the publish tool is still loading after **the integration host restarted**"* → post never sent.

There is no integration host to restart. That sentence is the agent rationalising a tool that was never going to arrive.

## The fix

Delegate to `refreshWorkspaceMcpTools`, already in the same file, which posts the **live** `/api/v1/capabilities/runtime-tools/mcp/refresh` capability — the same one the agent's `mcp_refresh` tool uses. It drops the workspace's MCP tool cache and (with the runtime-side companion) the cached Composio listing, so the next turn re-resolves both.

All three renderer call sites — chat connect proposal, add-app, marketplace install — are "something changed, make its tools reachable" moments, so all three want this. The existing IPC name is kept so the preload/renderer contract doesn't churn; the name is stale and worth retiring separately.

## Guards

A dead endpoint fails silently by construction — which is exactly why this survived — so the tests pin the live behaviour:

1. `composioMcpEnsureRunning` delegates to `refreshWorkspaceMcpTools`
2. nothing in the main process posts to the deleted route again
3. the refresh helper still targets the live capability

## Dependency

Depends on #540 for the Composio half: without it, the refresh capability drops only the pi MCP cache. **This change is still correct standalone** — it replaces a guaranteed 404 with a real refresh.

## Validation

- New guards **3/3**; **2 of 3 fail when the fix is reverted** (1 pass / 2 fail).
- Full desktop guard tier **135/135**.
- `bun run typecheck` in `apps/desktop` clean.