### PR TITLE
fix(runtime): surface integration toolkits that failed to resolve

### DIFF
--- a/apps/desktop/src/components/panes/ChatPane/index.tsx
+++ b/apps/desktop/src/components/panes/ChatPane/index.tsx
@@ -2219,13 +2219,20 @@ export function phaseTraceStepFromEvent(
     };
   }
 
-  if (eventType === "mcp_server_unavailable") {
+  if (
+    eventType === "mcp_server_unavailable" ||
+    eventType === "composio_toolkit_unavailable"
+  ) {
     // Don't surface this in the transcript at all. It's a recoverable notice —
     // the run continues without the server's tools (e.g. an OAuth connector never
     // signed into) — but rendering it every turn read as a failure and was pure
     // noise. The actionable paths live elsewhere: the inline authorize card
     // (mcpAuthorizations, collected in a separate pass) and Customize → MCPs →
     // Custom apps (sign in / remove). So emit no step.
+    //
+    // composio_toolkit_unavailable is the integration equivalent and gets the
+    // same treatment: it exists so a failed toolkit is diagnosable in the run
+    // trace, not so it becomes per-turn chrome.
     return null;
   }
 

--- a/runtime/api-server/src/ts-runner-contracts.ts
+++ b/runtime/api-server/src/ts-runner-contracts.ts
@@ -22,6 +22,7 @@ export type TsRunnerEventType =
   | "auto_compaction_start"
   | "auto_compaction_end"
   | "mcp_server_unavailable"
+  | "composio_toolkit_unavailable"
   | "run_completed"
   | "run_failed";
 

--- a/runtime/harness-host/src/contracts.test.ts
+++ b/runtime/harness-host/src/contracts.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -308,4 +309,40 @@ test("decode workspace MCP sidecar request payloads", () => {
       catalog_json_base64: "eyJ0ZXN0Ijp0cnVlfQ==",
     }
   );
+});
+
+/**
+ * An event type that isn't in BOTH unions is dropped on the way to the client —
+ * silently, which is the worst way for a diagnostic signal to fail. The runner
+ * and the ts-runner relay each carry their own copy of the list, so they can
+ * drift; pin them together.
+ */
+test("composio_toolkit_unavailable is a registered runner event", () => {
+  const event = {
+    session_id: "session-1",
+    input_id: "input-1",
+    sequence: 1,
+    // Fails typecheck if the type is missing from KnownRunnerEventType.
+    event_type: "composio_toolkit_unavailable",
+    payload: { toolkit_slug: "twitter", reason: "schema fetch failed" },
+  } satisfies RunnerOutputEvent;
+
+  assert.equal(event.event_type, "composio_toolkit_unavailable");
+});
+
+test("the ts-runner relay lists the same unavailable-event types as the runner", () => {
+  const relaySource = readFileSync(
+    new URL("../../api-server/src/ts-runner-contracts.ts", import.meta.url),
+    "utf8",
+  );
+
+  for (const eventType of [
+    "mcp_server_unavailable",
+    "composio_toolkit_unavailable",
+  ]) {
+    assert.ok(
+      relaySource.includes(`"${eventType}"`),
+      `${eventType} is emitted by the runner but not accepted by the ts-runner relay, so it never reaches the client`,
+    );
+  }
 });

--- a/runtime/harness-host/src/contracts.test.ts
+++ b/runtime/harness-host/src/contracts.test.ts
@@ -312,37 +312,57 @@ test("decode workspace MCP sidecar request payloads", () => {
 });
 
 /**
- * An event type that isn't in BOTH unions is dropped on the way to the client —
- * silently, which is the worst way for a diagnostic signal to fail. The runner
- * and the ts-runner relay each carry their own copy of the list, so they can
- * drift; pin them together.
+ * Both unions must list every event the runner emits.
+ *
+ * The first version of this test read only the RELAY source and compared it to a
+ * hardcoded array in the test body — so deleting the type from the runner union
+ * still passed, a comment counted as a match, and a future third type would be
+ * invisible. Parse both unions out of source and compare them as sets instead.
  */
-test("composio_toolkit_unavailable is a registered runner event", () => {
-  const event = {
-    session_id: "session-1",
-    input_id: "input-1",
-    sequence: 1,
-    // Fails typecheck if the type is missing from KnownRunnerEventType.
-    event_type: "composio_toolkit_unavailable",
-    payload: { toolkit_slug: "twitter", reason: "schema fetch failed" },
-  } satisfies RunnerOutputEvent;
+function unionMembers(file: string, typeName: string): Set<string> {
+  const source = readFileSync(new URL(file, import.meta.url), "utf8");
+  const start = source.indexOf(`export type ${typeName} =`);
+  if (start === -1) throw new Error(`${typeName} not found in ${file}`);
+  const body = source.slice(start, source.indexOf(";", start));
+  // Strip comments so a mention in prose never counts as membership.
+  const code = body.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  return new Set([...code.matchAll(/"([a-z0-9_]+)"/g)].map((m) => m[1]));
+}
 
-  assert.equal(event.event_type, "composio_toolkit_unavailable");
-});
+/**
+ * Pre-existing drift, deliberately allowed rather than silently blessed:
+ * `auto_retry_start` is declared by the runner and absent from the relay. It is
+ * not this change's to fix, but a NEW type landing in only one union should
+ * still fail here.
+ */
+const KNOWN_UNION_DRIFT = new Set(["auto_retry_start"]);
 
-test("the ts-runner relay lists the same unavailable-event types as the runner", () => {
-  const relaySource = readFileSync(
-    new URL("../../api-server/src/ts-runner-contracts.ts", import.meta.url),
-    "utf8",
+test("composio_toolkit_unavailable is declared by both the runner and the relay", () => {
+  const runner = unionMembers("./contracts.ts", "KnownRunnerEventType");
+  const relay = unionMembers(
+    "../../api-server/src/ts-runner-contracts.ts",
+    "TsRunnerEventType",
   );
 
-  for (const eventType of [
-    "mcp_server_unavailable",
-    "composio_toolkit_unavailable",
-  ]) {
-    assert.ok(
-      relaySource.includes(`"${eventType}"`),
-      `${eventType} is emitted by the runner but not accepted by the ts-runner relay, so it never reaches the client`,
-    );
-  }
+  // Load-bearing: without this, pi.ts's emit does not compile.
+  assert.ok(
+    runner.has("composio_toolkit_unavailable"),
+    "the runner union lost composio_toolkit_unavailable",
+  );
+  // Contract hygiene: the relay declares what it forwards.
+  assert.ok(
+    relay.has("composio_toolkit_unavailable"),
+    "the relay union lost composio_toolkit_unavailable",
+  );
+
+  assert.deepEqual(
+    [...runner].filter((t) => !relay.has(t) && !KNOWN_UNION_DRIFT.has(t)).sort(),
+    [],
+    "a runner event type is missing from the relay union",
+  );
+  assert.deepEqual(
+    [...relay].filter((t) => !runner.has(t)).sort(),
+    [],
+    "the relay declares an event type the runner cannot emit",
+  );
 });

--- a/runtime/harness-host/src/contracts.ts
+++ b/runtime/harness-host/src/contracts.ts
@@ -16,6 +16,7 @@ export type KnownRunnerEventType =
   | "auto_compaction_end"
   | "auto_retry_start"
   | "mcp_server_unavailable"
+  | "composio_toolkit_unavailable"
   | "run_completed"
   | "run_failed";
 

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -210,6 +210,10 @@ export interface PiSessionHandle {
   mcpToolMetadata: Map<string, PiMcpToolMetadata>;
   skillMetadataByAlias: Map<string, PiSkillMetadata>;
   unavailableMcpServers?: PiMcpServerUnavailableInfo[];
+  /** Toolkits whose inline Composio tools could not be resolved this turn. The
+   *  MCP path has surfaced its unavailable servers for a while; this is the
+   *  equivalent for integrations, which previously failed invisibly. */
+  unavailableComposioToolkits?: Array<{ toolkit_slug: string; reason: string }>;
   /** Per-step durations of the (currently serial) session-setup awaits —
    *  mcp_connect, composio_inline, runtime_tools, browser_tools, web_search,
    *  resource_reload, create_agent_session. Surfaced in run_started so the TTFT
@@ -3434,6 +3438,7 @@ async function defaultCreateSession(request: HarnessHostPiRequest): Promise<PiSe
     mcpToolMetadata: mcpToolset.mcpToolMetadata,
     skillMetadataByAlias,
     unavailableMcpServers: mcpToolset.unavailableServers,
+    unavailableComposioToolkits: composioInline.unavailable,
     setupTimingsMs,
     dispose: async () => {
       try {
@@ -4141,6 +4146,19 @@ export async function runPi(request: HarnessHostPiRequest, deps: PiDeps = defaul
       reason: unavailable.reason,
       missing_tool_ids: unavailable.missingToolIds,
       auth_required: unavailable.authRequired ?? false,
+    });
+  }
+
+  // The integration equivalent of the loop above. resolveComposioInlineTools has
+  // always returned which toolkits it could not resolve, but nothing consumed it,
+  // so a failed toolkit was indistinguishable from one the user never connected:
+  // the tools were simply absent and no event, log or prompt line said why. That
+  // is how a connected integration ends up explained to the user as "still
+  // loading" — the agent had no signal and guessed.
+  for (const unavailable of handle.unavailableComposioToolkits ?? []) {
+    emitEvent(request, nextSequence(), "composio_toolkit_unavailable", {
+      toolkit_slug: unavailable.toolkit_slug,
+      reason: unavailable.reason,
     });
   }
 


### PR DESCRIPTION
## The bug

`resolveComposioInlineTools` has always returned which toolkits it couldn't resolve:

```ts
export interface ResolveComposioInlineToolsResult {
  tools: HarnessRuntimeToolDefinitionLike[];
  unavailable: ComposioInlineUnavailableEntry[];   // ← computed, returned, and dropped
}
```

Nothing consumed it. `rg '\.unavailable\b'` in `pi.ts` returns **nothing**.

So a toolkit whose schema fetch failed was **indistinguishable from one the user never connected** — the tools were simply absent, with no event, no log line, and nothing in the prompt to say why.

**That's how a connected integration gets explained to the user as "still loading."** The agent had no signal, so it guessed — and its guess is what users read as the product explaining itself. Production transcripts are full of these invented explanations ("the integration host restarted", "the publish tool is still loading"), and this is why the agent had nothing better to say.

The MCP path has surfaced exactly this for a while via `mcp_server_unavailable`. Integrations just never got the equivalent.

## The fix

Carry `composioInline.unavailable` onto `PiSessionHandle` and emit `composio_toolkit_unavailable` alongside the existing MCP loop — same shape, same place, same lifecycle.

**Registered in both event unions.** `KnownRunnerEventType` (harness-host) and `TsRunnerEventType` (the ts-runner relay) each carry their own copy of the list, and a type missing from either is dropped on the way to the client — *silently*. That is precisely the failure mode this PR exists to end, so a contract test now pins the two lists together.

**No transcript noise.** The desktop treats it exactly like `mcp_server_unavailable`: no step rendered. That decision is already documented in `ChatPane` — a recoverable per-turn notice rendered as chrome read as failure and was pure noise. This event exists so a failed toolkit is **diagnosable in the run trace**, not so it becomes UI.

## Validation

- `contracts.test.ts` **10/10**, including a cross-package guard that **fails when the relay union drifts** — verified by removing the type (9 pass / 1 fail).
- `harness-host` **305/305**, `harnesses` **62/62**.
- `typecheck` clean in `runtime/harness-host`, `runtime/api-server`, and `apps/desktop`.

Independent of #540–#543, though it makes the same class of failure legible: those PRs stop the tools from going missing, this one makes it say so when they do.