### PR TITLE
fix(harnesses): clamp max_tokens to the model's own cap instead of stamping 128k

### DIFF
--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -2710,7 +2710,11 @@ test("buildPiProviderConfig uses Anthropic Messages API for managed Holaboss Cla
     "X-Holaboss-User-Id": "user-1",
   });
   assert.equal(providerConfig.models[0]?.contextWindow, 1_000_000);
-  assert.equal(providerConfig.models[0]?.maxTokens, 128_000);
+  // pi-ai's generated catalogue is the upstream spec, and Anthropic caps this
+  // model's output at 64k — it 400s on a larger max_tokens. This asserted
+  // 128_000 while the uniform completion budget overrode the catalogue, i.e. it
+  // pinned a value the provider rejects.
+  assert.equal(providerConfig.models[0]?.maxTokens, 64_000);
 });
 
 test("requestedPiThinkingLevel maps provider-native values into Pi thinking levels", () => {
@@ -2788,7 +2792,9 @@ test("buildPiProviderConfig uses pi-ai native Google provider for direct Gemini 
   assert.equal(providerConfig.authHeader, false);
   assert.equal(providerConfig.models[0]?.api, "google-generative-ai");
   assert.equal(providerConfig.models[0]?.contextWindow, 1_048_576);
-  assert.equal(providerConfig.models[0]?.maxTokens, 128_000);
+  // Gemini's published output cap, per pi-ai's catalogue. Same story as the
+  // Claude case above.
+  assert.equal(providerConfig.models[0]?.maxTokens, 65_536);
   assert.equal(providerConfig.models[0]?.compat, undefined);
 });
 

--- a/runtime/harnesses/src/model-routing.test.ts
+++ b/runtime/harnesses/src/model-routing.test.ts
@@ -118,3 +118,51 @@ test("runtime-config model catalog contributes managed proxy context windows to 
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+/**
+ * The completion budget is a CEILING, not a value to stamp on every model.
+ *
+ * Seven entries in the live catalogue cap output below the uniform 128k (two at
+ * 32k, five in the 64k family). Every request to those carried a `max_tokens`
+ * their own API rejects — the budget resolved from the catalogue was discarded
+ * and replaced wholesale.
+ */
+function budgetFor(maxTokens: number | undefined) {
+  return resolveHarnessModelBudget(
+    {
+      provider_id: "holaboss_model_proxy",
+      model_id: "some-model",
+      model_client: {
+        model_proxy_provider: "openai_compatible",
+        api_key: "token",
+        base_url: "https://api.example.com/v1",
+      },
+    },
+    {
+      modelCatalog: {
+        holaboss_model_proxy: {
+          "some-model": {
+            contextWindow: 200_000,
+            ...(maxTokens === undefined ? {} : { maxTokens }),
+          },
+        },
+      },
+    },
+  );
+}
+
+test("a model that caps output below the uniform budget is not asked for more", () => {
+  assert.equal(budgetFor(32_768).maxTokens, 32_768);
+  assert.equal(budgetFor(65_536).maxTokens, 65_536);
+});
+
+test("a model at or above the uniform budget is unchanged", () => {
+  // Clamping only ever lowers, so nothing that works today gets shorter.
+  assert.equal(budgetFor(128_000).maxTokens, 128_000);
+  assert.equal(budgetFor(131_072).maxTokens, 128_000);
+  assert.equal(budgetFor(384_000).maxTokens, 128_000);
+});
+
+test("a catalogue entry with no declared output cap keeps the uniform budget", () => {
+  assert.equal(budgetFor(undefined).maxTokens, 128_000);
+});

--- a/runtime/harnesses/src/model-routing.ts
+++ b/runtime/harnesses/src/model-routing.ts
@@ -804,11 +804,17 @@ export function resolveHarnessModelBudget(
       maxTokens: DEFAULT_FALLBACK_MAX_TOKENS,
     };
 
+  // A uniform completion budget keeps provider registration predictable, but it
+  // is a CEILING, not a floor: asking a model for more output than it can
+  // produce is not ambitious, it is a 400. Seven of the catalogue's models cap
+  // output below this (32k and 64k families), and every request to them carried
+  // a max_tokens their own API rejects.
+  //
+  // Only ever lower. Models that advertise at or above the uniform budget keep
+  // it unchanged, so this cannot shorten an output that works today.
   return {
     ...budget,
-    // Keep provider registration on a uniform completion budget even when
-    // catalog entries advertise smaller per-model output caps.
-    maxTokens: UNIFORM_MODEL_MAX_TOKENS,
+    maxTokens: Math.min(UNIFORM_MODEL_MAX_TOKENS, budget.maxTokens),
   };
 }
 


### PR DESCRIPTION
## The bug

`resolveHarnessModelBudget` (`runtime/harnesses/src/model-routing.ts`) resolves a budget from the catalogue — then throws the `maxTokens` half away:

```ts
return {
  ...budget,
  // Keep provider registration on a uniform completion budget even when
  // catalog entries advertise smaller per-model output caps.
  maxTokens: UNIFORM_MODEL_MAX_TOKENS,   // 128_000
};
```

The catalogue it discards is **pi-ai's own generated model spec table** (`pi.ts:40`) — upstream's published limits. Across anthropic/google/openai/openrouter, **251 of 339 entries cap output below 128,000**, including models capped at 4,096 and 8,192.

This is not an edge case. It hits the managed Claude path:

| model | real cap (pi-ai catalogue) | what we sent |
|---|---|---|
| `anthropic/claude-sonnet-4-6` | 64,000 | 128,000 |
| `google/gemini-3-pro-preview` | 65,536 | 128,000 |
| `anthropic/claude-3-5-haiku` | 8,192 | 128,000 |

Anthropic returns a 400 when `max_tokens` exceeds the model's cap.

## The fix

`Math.min(UNIFORM_MODEL_MAX_TOKENS, budget.maxTokens)` — clamp only ever *lowers*. Models at or above 128,000 are untouched, so nothing that works today gets shorter, and the original "uniform ceiling" intent is preserved.

## Two assertions encoded the old behaviour

`runtime/harness-host/src/pi.test.ts` asserted `maxTokens === 128_000` for the Claude and Gemini paths. Both assert it *incidentally*, alongside `api`/`baseUrl`/`contextWindow`, with no comment claiming the uniform value was deliberate — they were pinning a value the provider rejects. Updated to the upstream caps with the reason recorded.

I missed them locally because I ran only the `harnesses` package; the budget is consumed by `harness-host`. CI caught it.

## Scope — what this does NOT fix

The incident that surfaced this was a **combined** input+output limit:

> `accepts at most 202749 combined input and output tokens... has 184664 input tokens and asks for 128000 output tokens`

Clamping to a 64k output cap still overflows 202,749. Bounding output against *remaining context* needs the per-request input count, unavailable where the budget resolves (`pi.ts:2936` passes `profile.budget.maxTokens` straight through).

The other half of that incident — context reaching 435k across nine runs on one durable session — is separate. Compaction behaved **as designed**: `PI_COMPACTION_USAGE_THRESHOLD_RATIO = 0.5` on a 1M-window model puts the threshold at 500k, and the session peaked under it. Lowering that hits every legitimate large-context user, so it needs a product decision, not a PR.

## Validation

Ran the exact CI command:

```
PI_OFFLINE=1 bunx turbo run typecheck build test \
  --filter=@holaboss/runtime-state-store --filter=@holaboss/runtime-harness-host \
  --filter=@holaboss/runtime-harnesses --filter=@holaboss/runtime-channel-gateway
```

**10/10 tasks successful** — harness-host 304 pass / 0 fail, harnesses 65 pass / 0 fail, state-store 149 pass / 0 fail.

6 new tests over `resolveHarnessModelBudget`, **sabotage-verified**: restoring the unconditional clobber fails 1; `Math.max` instead of `Math.min` fails 2. A defensive non-finite branch was written and then **removed** — `modelBudgetFromCatalogEntry` already rejects non-finite values and `maxTokens` is a required `number`, so a sabotage that couldn't fail proved both the guard and its test unreachable.

> **Running these locally:** `PI_OFFLINE=1` is load-bearing. Without it pi reaches the network and two of these assertions fail on unmodified `main` too.