### PR TITLE
fix(harness-host): let Anthropic turns use the 1h prompt cache, not the 5m default

### DIFF
--- a/runtime/harness-host/src/pi.test.ts
+++ b/runtime/harness-host/src/pi.test.ts
@@ -2665,7 +2665,7 @@ test("buildPiProviderConfig preserves catalog pricing after runtime provider reg
 // @earendil 0.80 handles long/24h prompt-cache retention natively via the
 // PI_CACHE_RETENTION env — resolveCacheRetention() reads it regardless of baseUrl, so
 // patch 2's "gate on api.openai.com" hack is obsolete. Our configurePiPromptCacheRetention
-// sets that env for openai-responses models (which carries into PI's internal
+// sets that env for the APIs whose providers honour it (which carries into PI's internal
 // compaction/summarization requests too) and no-ops otherwise. This verifies our side.
 test("configurePiPromptCacheRetention enables PI_CACHE_RETENTION=long for openai-responses models", () => {
   const previous = process.env.PI_CACHE_RETENTION;
@@ -2676,9 +2676,23 @@ test("configurePiPromptCacheRetention enables PI_CACHE_RETENTION=long for openai
     restore();
     assert.equal(process.env.PI_CACHE_RETENTION, undefined);
 
-    const restoreAnthropic = configurePiPromptCacheRetention({ ...baseRequest(), model_id: "claude-sonnet-4-6" });
-    assert.equal(process.env.PI_CACHE_RETENTION, undefined);
+    // Anthropic honours it too — pi-ai only emits `ttl: "1h"` when retention is
+    // "long", and supportsLongCacheRetention already defaults to true. Leaving
+    // this unset pinned every Anthropic turn to the 5-minute TTL, re-billing the
+    // whole prompt at full price after any longer pause.
+    const restoreAnthropic = configurePiPromptCacheRetention({
+      ...baseRequest(),
+      provider_id: "holaboss_model_proxy",
+      model_id: "claude-sonnet-4-6",
+      model_client: {
+        model_proxy_provider: "anthropic_native",
+        api_key: "hbmk-test",
+        base_url: "http://127.0.0.1:3060/api/v1/model-proxy/anthropic/v1",
+      },
+    });
+    assert.equal(process.env.PI_CACHE_RETENTION, "long");
     restoreAnthropic();
+    assert.equal(process.env.PI_CACHE_RETENTION, undefined);
   } finally {
     if (previous === undefined) {
       delete process.env.PI_CACHE_RETENTION;
@@ -5103,5 +5117,55 @@ test("toolCallTimeoutMs bounds bash by default and leaves other tools unbounded"
     else process.env.HOLABOSS_BASH_TOOL_TIMEOUT_S = prevBash;
     if (prevAll === undefined) delete process.env.HOLABOSS_TOOL_CALL_TIMEOUT_S;
     else process.env.HOLABOSS_TOOL_CALL_TIMEOUT_S = prevAll;
+  }
+});
+
+/**
+ * The retention hint is only correct for providers that actually honour it.
+ * Setting it for the others would be a silent lie in the env that PI's internal
+ * compaction requests also read.
+ */
+test("configurePiPromptCacheRetention no-ops for APIs that do not honour retention", () => {
+  const previous = process.env.PI_CACHE_RETENTION;
+  delete process.env.PI_CACHE_RETENTION;
+  try {
+    for (const request of [
+      // openai-completions: a managed OpenAI-compatible model.
+      {
+        ...baseRequest(),
+        provider_id: "holaboss_model_proxy",
+        model_id: "qwen/qwen3.7-plus",
+        model_client: {
+          model_proxy_provider: "openai_compatible" as const,
+          api_key: "hbmk-test",
+          base_url: "http://127.0.0.1:3060/api/v1/model-proxy/v1",
+        },
+      },
+      // google-generative-ai: the native Gemini path.
+      {
+        ...baseRequest(),
+        provider_id: "gemini_direct",
+        model_id: "gemini-2.5-pro",
+        model_client: {
+          model_proxy_provider: "google_compatible" as const,
+          api_key: "g-test",
+          base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
+        },
+      },
+    ]) {
+      const restore = configurePiPromptCacheRetention(request);
+      assert.equal(
+        process.env.PI_CACHE_RETENTION,
+        undefined,
+        `${request.model_id} should not set a retention hint`,
+      );
+      restore();
+    }
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_CACHE_RETENTION;
+    } else {
+      process.env.PI_CACHE_RETENTION = previous;
+    }
   }
 });

--- a/runtime/harness-host/src/pi.ts
+++ b/runtime/harness-host/src/pi.ts
@@ -2776,8 +2776,30 @@ function resolvePiModelProfile(request: HarnessHostPiRequest) {
   });
 }
 
+/**
+ * APIs whose providers honour a long prompt-cache retention hint.
+ *
+ * `anthropic-messages` was missing here, and the omission was expensive. pi-ai
+ * computes `ttl = retention === "long" && supportsLongCacheRetention ? "1h" :
+ * undefined` (anthropic-messages.js), `resolveCacheRetention` defaults to
+ * "short", and `supportsLongCacheRetention` already defaults to TRUE — so every
+ * Anthropic turn shipped a bare `{type: "ephemeral"}` and fell back to the
+ * 5-minute TTL. Any pause longer than that re-billed the whole prompt at full
+ * price.
+ *
+ * Measured on one production session: two turns with byte-identical input
+ * (425,100 tokens) billed 1,062,749 vs 156,044 — 6.8x — separated only by
+ * whether the gap before them exceeded five minutes. Across 14 days on the same
+ * upstream, the guarded `openai-responses` path ran an 89.3% cache-hit rate
+ * while `anthropic-messages` ran 26.7%.
+ */
+const LONG_CACHE_RETENTION_APIS: ReadonlySet<string> = new Set([
+  "openai-responses",
+  "anthropic-messages",
+]);
+
 export function configurePiPromptCacheRetention(request: HarnessHostPiRequest): () => void {
-  if (resolvePiModelProfile(request).api !== "openai-responses") {
+  if (!LONG_CACHE_RETENTION_APIS.has(resolvePiModelProfile(request).api)) {
     return () => {};
   }
   const previousValue = process.env.PI_CACHE_RETENTION;


### PR DESCRIPTION
## The bug

`configurePiPromptCacheRetention` (`runtime/harness-host/src/pi.ts`) set `PI_CACHE_RETENTION=long` **only** for `openai-responses`. Every `anthropic-messages` turn therefore shipped a bare `{type: "ephemeral"}` cache_control and fell back to Anthropic's **5-minute** TTL — so any pause longer than that re-billed the whole prompt at full price.

Nothing else was missing. pi-ai already does the right thing when told:

- `anthropic-messages.js:30` — `ttl = retention === "long" && supportsLongCacheRetention ? "1h" : undefined`
- `:15-23` — `resolveCacheRetention` defaults to `"short"`
- `getAnthropicCompat:112` — `supportsLongCacheRetention` already defaults to **true**

The hint was simply never set for this API.

## The cost, measured

One production session, two turns with **byte-identical input** (425,100 tokens):

| time | input | cached | billed | gap before |
|---|---|---|---|---|
| 08:35:53 | 425,100 | 0 | **1,062,749** | 5m36s |
| 08:37:24 | 425,100 | 425,098 | **156,044** | 1m31s |

**6.8×** on identical bytes. Every miss in that session followed a gap >5min; every hit followed <5min — textbook ephemeral-TTL expiry.

Across 14 days against the **same upstream**:

| path | guard applies? | cache-hit rate | owners |
|---|---|---|---|
| `/responses` | yes | **89.3%** | 231 |
| `/messages` | **no** | **26.7%** | 325 |

## Chronic in code, recent in effect

Anthropic `/messages` averaged **2 input tokens** per call through Aug 17, so the defect cost nothing until that path took real context on Aug 18–19 — exactly when the negative-balance spike begins (users pushed negative per day: 1 → 9 → **91** → 77).

## Scope

Deliberately limited to the two APIs whose providers honour the hint. `PI_CACHE_RETENTION` is a process env that PI's internal compaction/summarization requests also read, so setting it for a provider that ignores it would be a silent lie in shared state. The over-application direction is covered by a test.

On the economics: 1h cache *writes* cost 2× base against 1.25× for 5m, so this is a net win only while conversion is high enough to pay for the more expensive write. At a 26.7% hit rate on 100k+ token contexts — with the `/responses` path demonstrating 89.3% is achievable on the same upstream — it clears that comfortably.

## Validation

101 tests in `pi.test.ts`. The existing case **asserted the old behaviour** (`assert.equal(process.env.PI_CACHE_RETENTION, undefined)` for a Claude model) and was updated — it pinned the bug, not intent.

**Sabotage-verified, all four fail:**

| sabotage | result |
|---|---|
| revert to `openai-responses` only | **1 fail** |
| drop `anthropic-messages` from the set | **1 fail** |
| apply to **every** api (over-application) | **1 fail** |
| break the restore semantics | **1 fail** |

Exact CI command — `PI_OFFLINE=1 bunx turbo run typecheck build test` across all four runtime filters: **10/10 tasks successful**.

> `PI_OFFLINE=1` is load-bearing when running these locally; without it pi reaches the network and unrelated assertions fail on `main` too.